### PR TITLE
Admin panel for mysql config and content editing

### DIFF
--- a/src/admin/index.html
+++ b/src/admin/index.html
@@ -1,4 +1,1 @@
-<h2>Oops!</h2>
-This is a dev release of ts-website. There is no admin panel yet.<br>
-Modify the database directly to change the configuration.<br>
-<a href="..">Go back</a>
+<meta http-equiv="refresh" content="0; url=index.php">

--- a/src/admin/index.php
+++ b/src/admin/index.php
@@ -1,0 +1,24 @@
+<?php
+
+use Wruczek\TSWebsite\Auth;
+use Wruczek\TSWebsite\Config;
+use Wruczek\TSWebsite\Utils\TemplateUtils;
+
+require_once __DIR__ . "/../private/php/load.php";
+
+if (!Auth::isLoggedIn() || Auth::getCldbid() !== 3) {
+    http_response_code(403);
+    TemplateUtils::i()->renderErrorTemplate("403", "Forbidden", "You do not have access to this page.");
+    exit;
+}
+
+$data = [
+    "pagetitle" => "Admin Panel",
+    "navActiveIndex" => 0,
+    "assignerConfigJson" => json_encode(Config::get("assignerconfig") ?? [], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES),
+    "adminStatusGroupsJson" => json_encode(Config::get("adminstatus_groups") ?? [], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES),
+    "rulesHtml" => (string) (Config::get("rules_html") ?? "<p>Rules in <b>HTML</b></p>"),
+];
+
+TemplateUtils::i()->renderTemplate("admin", $data);
+

--- a/src/api/save-config.php
+++ b/src/api/save-config.php
@@ -1,0 +1,42 @@
+<?php
+
+use Wruczek\TSWebsite\Auth;
+use Wruczek\TSWebsite\Config;
+use Wruczek\TSWebsite\Utils\ApiUtils;
+
+require_once __DIR__ . "/../private/php/load.php";
+
+header('Content-Type: application/json');
+
+if (!Auth::isLoggedIn() || Auth::getCldbid() !== 3) {
+    http_response_code(403);
+    echo json_encode(["ok" => false, "error" => "forbidden"]);
+    exit;
+}
+
+try {
+    $assigner = @$_POST["assignerconfig"] ?? '';
+    $adminGroups = @$_POST["adminstatus_groups"] ?? '';
+
+    if ($assigner !== '') {
+        $assignerJson = json_decode($assigner, true);
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            throw new \InvalidArgumentException("assignerconfig must be valid JSON");
+        }
+        Config::i()->setValue("assignerconfig", $assignerJson);
+    }
+
+    if ($adminGroups !== '') {
+        $groupsJson = json_decode($adminGroups, true);
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            throw new \InvalidArgumentException("adminstatus_groups must be valid JSON");
+        }
+        Config::i()->setValue("adminstatus_groups", $groupsJson);
+    }
+
+    echo json_encode(["ok" => true]);
+} catch (\Throwable $e) {
+    http_response_code(400);
+    echo json_encode(["ok" => false, "error" => $e->getMessage()]);
+}
+

--- a/src/api/save-news.php
+++ b/src/api/save-news.php
@@ -1,0 +1,32 @@
+<?php
+
+use Wruczek\TSWebsite\Auth;
+use Wruczek\TSWebsite\Utils\Utils;
+
+require_once __DIR__ . "/../private/php/load.php";
+
+header('Content-Type: application/json');
+
+if (!Auth::isLoggedIn() || Auth::getCldbid() !== 3) {
+    http_response_code(403);
+    echo json_encode(["ok" => false, "error" => "forbidden"]);
+    exit;
+}
+
+$title = trim((string) (@$_POST["title"] ?? ''));
+$content = (string) (@$_POST["content"] ?? '');
+
+if ($title === '' || $content === '') {
+    http_response_code(400);
+    echo json_encode(["ok" => false, "error" => "title and content required"]);
+    exit;
+}
+
+try {
+    Utils::getNewsStore()->addNews($title, $content);
+    echo json_encode(["ok" => true]);
+} catch (\Throwable $e) {
+    http_response_code(400);
+    echo json_encode(["ok" => false, "error" => $e->getMessage()]);
+}
+

--- a/src/api/save-rules.php
+++ b/src/api/save-rules.php
@@ -1,0 +1,25 @@
+<?php
+
+use Wruczek\TSWebsite\Auth;
+use Wruczek\TSWebsite\Config;
+
+require_once __DIR__ . "/../private/php/load.php";
+
+header('Content-Type: application/json');
+
+if (!Auth::isLoggedIn() || Auth::getCldbid() !== 3) {
+    http_response_code(403);
+    echo json_encode(["ok" => false, "error" => "forbidden"]);
+    exit;
+}
+
+$rules = (string) (@$_POST["rules_html"] ?? '');
+
+try {
+    Config::i()->setValue("rules_html", $rules);
+    echo json_encode(["ok" => true]);
+} catch (\Throwable $e) {
+    http_response_code(400);
+    echo json_encode(["ok" => false, "error" => $e->getMessage()]);
+}
+

--- a/src/private/templates/admin.latte
+++ b/src/private/templates/admin.latte
@@ -1,0 +1,40 @@
+{extends "body.latte"}
+{var $title = $pagetitle}
+
+{block content}
+<div class="card card-accent mb-3">
+    <div class="card-header bigger-title">
+        <i class="fas fa-tools"></i> Admin Panel
+    </div>
+    <div class="card-body">
+        <p>Only user with CLDBID 3 can access this page.</p>
+
+        <form id="form-config" method="post" action="api/save-config.php" class="mb-4">
+            {$csrfField}
+            <h5>Assigner Config (JSON)</h5>
+            <textarea class="form-control mb-2" name="assignerconfig" rows="10">{$assignerConfigJson|noescape}</textarea>
+
+            <h5 class="mt-3">Admin Status Groups (JSON)</h5>
+            <textarea class="form-control mb-2" name="adminstatus_groups" rows="6">{$adminStatusGroupsJson|noescape}</textarea>
+
+            <button type="submit" class="btn btn-primary"><i class="fas fa-save"></i> Save Config</button>
+        </form>
+
+        <form id="form-rules" method="post" action="api/save-rules.php" class="mb-4">
+            {$csrfField}
+            <h5>Rules HTML</h5>
+            <textarea class="form-control mb-2" name="rules_html" rows="10">{$rulesHtml|noescape}</textarea>
+            <button type="submit" class="btn btn-primary"><i class="fas fa-save"></i> Save Rules</button>
+        </form>
+
+        <form id="form-news" method="post" action="api/save-news.php">
+            {$csrfField}
+            <h5>Post News</h5>
+            <input type="text" class="form-control mb-2" name="title" placeholder="Title" required>
+            <textarea class="form-control mb-2" name="content" rows="8" placeholder="HTML content" required></textarea>
+            <button type="submit" class="btn btn-success"><i class="fas fa-plus"></i> Add News</button>
+        </form>
+    </div>
+</div>
+{/block}
+

--- a/src/rules.php
+++ b/src/rules.php
@@ -1,6 +1,7 @@
 <?php
 
 use Wruczek\TSWebsite\Utils\TemplateUtils;
+use Wruczek\TSWebsite\Config;
 
 require_once __DIR__ . "/private/php/load.php";
 
@@ -8,7 +9,7 @@ $data = [
     "pagetitle" => __get("RULES_TITLE"),
     "navActiveIndex" => 4,
     "paneltitle" => '<i class="fas fa-book"></i>' . __get("RULES_PANEL_TITLE"),
-    "panelcontent" => "Rules in <b>HTML</b>"
+    "panelcontent" => (string) (Config::get("rules_html") ?? "Rules in <b>HTML</b>")
 ];
 
 TemplateUtils::i()->renderTemplate("simple-page", $data);


### PR DESCRIPTION
Add a secure admin panel for `cldbid` user 3 to manage `assignerConfig`, `adminstatus_groups`, rules content, and news posts.

---
<a href="https://cursor.com/background-agent?bcId=bc-822fb319-e813-47cb-a8e9-c8ce29257c00"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-822fb319-e813-47cb-a8e9-c8ce29257c00"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

