### PR TITLE
Update assigner and admin config locally

### DIFF
--- a/src/private/config.local.php
+++ b/src/private/config.local.php
@@ -1,0 +1,18 @@
+<?php
+
+// Local configuration overrides.
+// Return key => value pairs. Values should be proper PHP types.
+return [
+    // Minimal assigner config with a single category using group ID 7
+    'assignerconfig' => [
+        [
+            'name' => 'Local Assigner',
+            'max' => 1,
+            'groups' => [7],
+        ],
+    ],
+
+    // Admin status will display members of server group ID 6
+    'adminstatus_groups' => [6],
+];
+

--- a/src/private/php/Config.php
+++ b/src/private/php/Config.php
@@ -55,6 +55,13 @@ class Config {
                 $db = DatabaseUtils::i()->getDb();
                 $data = $db->select("config", ["identifier", "type", "value"]);
             } catch (\Exception $e) {
+                // If DB is unavailable, fall back to local overrides if present
+                $overrides = $this->getLocalOverrides();
+                if (!empty($overrides)) {
+                    $this->config = $overrides;
+                    return $this->config;
+                }
+
                 TemplateUtils::i()->renderErrorTemplate("DB error", "Cannot get config data from database", $e->getMessage());
                 exit;
             }
@@ -93,6 +100,12 @@ class Config {
                 }
 
                 $cfg[$key] = $val;
+            }
+
+            // Merge local overrides (if any) so they take precedence over DB values
+            $overrides = $this->getLocalOverrides();
+            if (!empty($overrides)) {
+                $cfg = array_replace($cfg, $overrides);
             }
 
             $this->config = $cfg;
@@ -165,5 +178,23 @@ class Config {
         }
 
         $this->clearConfigCache();
+    }
+
+    /**
+     * Loads local configuration overrides from private/config.local.php if present.
+     * This file should return a simple associative array of key => value pairs,
+     * where values are already typed PHP values (string|int|float|bool|array|object).
+     */
+    private function getLocalOverrides(): array {
+        $localConfigPath = __PRIVATE_DIR . "/config.local.php";
+
+        if (file_exists($localConfigPath)) {
+            $overrides = require $localConfigPath;
+            if (is_array($overrides)) {
+                return $overrides;
+            }
+        }
+
+        return [];
     }
 }


### PR DESCRIPTION
Add local configuration override mechanism to allow `assignerconfig` and `adminstatus_groups` to be set without database access.

---
<a href="https://cursor.com/background-agent?bcId=bc-6e40b74f-4710-4129-b61f-16d84b15326c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6e40b74f-4710-4129-b61f-16d84b15326c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

