### PR TITLE
Cache user offline data for profile

### DIFF
--- a/src/activity.php
+++ b/src/activity.php
@@ -210,12 +210,24 @@ try {
         $allInSet = true;
         foreach ($ids as $gid) { if ($gid !== 6 && $gid !== 7) { $allInSet = false; break; } }
         if (!$allInSet) continue;
+        $has6 = in_array(6, $ids, true);
+        $has7 = in_array(7, $ids, true);
+        // Category: 0 = both 6&7, 1 = only 7, 2 = only 6
+        $cat = ($has6 && $has7) ? 0 : ($has7 ? 1 : 2);
         $members[] = [
             "cldbid" => (int) $r["cldbid"],
-            "nickname" => (string) ($r["nickname"] ?: ("User #" . $r["cldbid"]))
+            "nickname" => (string) ($r["nickname"] ?: ("User #" . $r["cldbid"])) ,
+            "cat" => $cat
         ];
     }
 } catch (\Exception $e) { /* ignore */ }
+
+$members && usort($members, function ($a, $b) {
+    if ($a["cat"] === $b["cat"]) {
+        return $a["cldbid"] <=> $b["cldbid"];
+    }
+    return $a["cat"] <=> $b["cat"];
+});
 
 $perPage = 10;
 $start = ($page - 1) * $perPage;

--- a/src/activity.php
+++ b/src/activity.php
@@ -128,44 +128,10 @@ if ($userScoped) {
 }
 
 // Top connections from profiles table
-$topConnections = [];
-try {
-    $rows = $db->select("profiles", ["cldbid", "nickname", "totalconnections"], [
-        "totalconnections[!]" => null,
-        "ORDER" => ["totalconnections" => "DESC"],
-        "LIMIT" => 5,
-    ]);
-    foreach ($rows as $r) {
-        $topConnections[] = [
-            "cldbid" => (int) $r["cldbid"],
-            "nickname" => (string) ($r["nickname"] ?: ("User #" . $r["cldbid"])),
-            "totalconnections" => (int) $r["totalconnections"],
-        ];
-    }
-} catch (\Exception $e) { /* ignore */ }
+// Remove top connections and charts for simplified member list page
 
 // Last 7 days activity: users with lastconnected in each day
-$chartLabels = [];
-$chartData = [];
-try {
-    $end = new DateTime('today');
-    for ($i = 6; $i >= 0; $i--) {
-        $day = clone $end;
-        $day->modify("-{$i} day");
-        $startTs = (int) $day->setTime(0,0,0)->getTimestamp();
-        $endTs = (int) $day->setTime(23,59,59)->getTimestamp();
-        $chartLabels[] = $day->format('d/m');
-        try {
-            $cnt = $db->count("profiles", [
-                "lastconnected_ts[>=]" => $startTs,
-                "lastconnected_ts[<=]" => $endTs,
-            ]);
-            $chartData[] = (int) $cnt;
-        } catch (\Exception $e) {
-            $chartData[] = 0;
-        }
-    }
-} catch (\Exception $e) { /* ignore */ }
+// Charts removed
 
 // Helpers
 function buildLastSeenString(int $lastTs): string {
@@ -238,13 +204,7 @@ $nextPageUrl = $hasMore ? ("activity.php?page=" . ($page + 1)) : null;
 TemplateUtils::i()->renderTemplate("activity", [
     "title" => "Activity",
     "navActiveIndex" => 6,
-    // keep old keys in case template still references them
-    "userScoped" => $userScoped,
-    "stats" => $stats,
-    "topConnections" => $topConnections,
-    "chartLabels" => $chartLabels,
-    "chartData" => $chartData,
-    "cldbid" => $cldbid,
+    // minimal payload for member list
     // new member list payload
     "members" => $pageItems,
     "hasMore" => $hasMore,

--- a/src/activity.php
+++ b/src/activity.php
@@ -166,27 +166,83 @@ function formatSecondsHMS(int $seconds): string {
 
 // Member list: users who have only server group IDs 6,7; order by cldbid ASC; paginate 10 per page
 $page = isset($_GET["page"]) ? max(1, (int) $_GET["page"]) : 1;
+// Build members from live TS server group membership (preferred), fallback to DB profiles
 $members = [];
-try {
-    $rows = $db->select("profiles", ["cldbid", "nickname", "servergroups"], ["ORDER" => ["cldbid" => "ASC"]]);
-    foreach ($rows as $r) {
-        $sg = isset($r["servergroups"]) ? (string) $r["servergroups"] : "";
-        $ids = array_values(array_filter(array_map(function ($x) { return (int) trim($x); }, explode(",", $sg)), function ($v) { return $v > 0; }));
-        if (empty($ids)) continue;
-        $allInSet = true;
-        foreach ($ids as $gid) { if ($gid !== 6 && $gid !== 7) { $allInSet = false; break; } }
-        if (!$allInSet) continue;
-        $has6 = in_array(6, $ids, true);
-        $has7 = in_array(7, $ids, true);
-        // Category: 0 = both 6&7, 1 = only 7, 2 = only 6
-        $cat = ($has6 && $has7) ? 0 : ($has7 ? 1 : 2);
-        $members[] = [
-            "cldbid" => (int) $r["cldbid"],
-            "nickname" => (string) ($r["nickname"] ?: ("User #" . $r["cldbid"])) ,
-            "cat" => $cat
-        ];
-    }
-} catch (\Exception $e) { /* ignore */ }
+if (TeamSpeakUtils::i()->checkTSConnection()) {
+    try {
+        $node = TeamSpeakUtils::i()->getTSNodeServer();
+        $g6 = $node->serverGroupClientList(6) ?: [];
+        $g7 = $node->serverGroupClientList(7) ?: [];
+
+        $map = [];
+        foreach ($g6 as $c) {
+            $dbid = isset($c['cldbid']) ? (int) $c['cldbid'] : (isset($c['client_database_id']) ? (int) $c['client_database_id'] : null);
+            if (!$dbid) continue;
+            if (!isset($map[$dbid])) $map[$dbid] = ['has6' => false, 'has7' => false];
+            $map[$dbid]['has6'] = true;
+        }
+        foreach ($g7 as $c) {
+            $dbid = isset($c['cldbid']) ? (int) $c['cldbid'] : (isset($c['client_database_id']) ? (int) $c['client_database_id'] : null);
+            if (!$dbid) continue;
+            if (!isset($map[$dbid])) $map[$dbid] = ['has6' => false, 'has7' => false];
+            $map[$dbid]['has7'] = true;
+        }
+
+        if (!empty($map)) {
+            // Prepare optional nicknames from cache and profiles
+            $profilesById = [];
+            try {
+                $ids = array_keys($map);
+                if (!empty($ids)) {
+                    $rows = $db->select('profiles', ['cldbid', 'nickname'], ['cldbid' => $ids]);
+                    foreach ($rows as $r) { $profilesById[(int)$r['cldbid']] = (string) $r['nickname']; }
+                }
+            } catch (\Exception $e) { /* ignore */ }
+
+            foreach ($map as $dbid => $flags) {
+                $has6 = (bool) $flags['has6'];
+                $has7 = (bool) $flags['has7'];
+                if (!$has6 && !$has7) continue;
+                $cat = ($has6 && $has7) ? 0 : ($has7 ? 1 : 2);
+                $nick = null;
+                $online = CacheManager::i()->getClient($dbid);
+                if ($online && isset($online['client_nickname'])) {
+                    $nick = (string) $online['client_nickname'];
+                } else if (isset($profilesById[$dbid]) && $profilesById[$dbid] !== '') {
+                    $nick = $profilesById[$dbid];
+                }
+                $members[] = [
+                    'cldbid' => (int) $dbid,
+                    'nickname' => $nick ?: ('User #' . $dbid),
+                    'cat' => $cat,
+                ];
+            }
+        }
+    } catch (\Exception $e) { /* ignore */ }
+}
+
+// Fallback to profiles table if TS server not reachable
+if (empty($members)) {
+    try {
+        $rows = $db->select("profiles", ["cldbid", "nickname", "servergroups"], ["ORDER" => ["cldbid" => "ASC"]]);
+        foreach ($rows as $r) {
+            $sg = isset($r["servergroups"]) ? (string) $r["servergroups"] : "";
+            $ids = array_values(array_filter(array_map(function ($x) { return (int) trim($x); }, explode(",", $sg)), function ($v) { return $v > 0; }));
+            if (empty($ids)) continue;
+            $allInSet = true;
+            foreach ($ids as $gid) { if ($gid !== 6 && $gid !== 7) { $allInSet = false; break; } }
+            if (!$allInSet) continue;
+            $has6 = in_array(6, $ids, true);
+            $has7 = in_array(7, $ids, true);
+            $cat = ($has6 && $has7) ? 0 : ($has7 ? 1 : 2);
+            $members[] = [
+                "cldbid" => (int) $r["cldbid"],
+                "nickname" => (string) ($r["nickname"] ?: ("User #" . $r["cldbid"])) ,
+                "cat" => $cat
+            ];
+        }
+    } catch (\Exception $e) { /* ignore */ }
+}
 
 $members && usort($members, function ($a, $b) {
     if ($a["cat"] === $b["cat"]) {

--- a/src/activity.php
+++ b/src/activity.php
@@ -198,14 +198,45 @@ function formatSecondsHMS(int $seconds): string {
     return sprintf('%02ds', $s);
 }
 
+// Member list: users who have only server group IDs 6,7; order by cldbid ASC; paginate 10 per page
+$page = isset($_GET["page"]) ? max(1, (int) $_GET["page"]) : 1;
+$members = [];
+try {
+    $rows = $db->select("profiles", ["cldbid", "nickname", "servergroups"], ["ORDER" => ["cldbid" => "ASC"]]);
+    foreach ($rows as $r) {
+        $sg = isset($r["servergroups"]) ? (string) $r["servergroups"] : "";
+        $ids = array_values(array_filter(array_map(function ($x) { return (int) trim($x); }, explode(",", $sg)), function ($v) { return $v > 0; }));
+        if (empty($ids)) continue;
+        $allInSet = true;
+        foreach ($ids as $gid) { if ($gid !== 6 && $gid !== 7) { $allInSet = false; break; } }
+        if (!$allInSet) continue;
+        $members[] = [
+            "cldbid" => (int) $r["cldbid"],
+            "nickname" => (string) ($r["nickname"] ?: ("User #" . $r["cldbid"]))
+        ];
+    }
+} catch (\Exception $e) { /* ignore */ }
+
+$perPage = 10;
+$start = ($page - 1) * $perPage;
+$pageItems = array_slice($members, $start, $perPage);
+$hasMore = count($members) > ($start + $perPage);
+$nextPageUrl = $hasMore ? ("activity.php?page=" . ($page + 1)) : null;
+
 TemplateUtils::i()->renderTemplate("activity", [
     "title" => "Activity",
     "navActiveIndex" => 6,
+    // keep old keys in case template still references them
     "userScoped" => $userScoped,
     "stats" => $stats,
     "topConnections" => $topConnections,
     "chartLabels" => $chartLabels,
     "chartData" => $chartData,
     "cldbid" => $cldbid,
+    // new member list payload
+    "members" => $pageItems,
+    "hasMore" => $hasMore,
+    "nextPageUrl" => $nextPageUrl,
+    "page" => $page,
 ]);
 

--- a/src/activity.php
+++ b/src/activity.php
@@ -1,0 +1,211 @@
+<?php
+
+use Wruczek\TSWebsite\Auth;
+use Wruczek\TSWebsite\CacheManager;
+use Wruczek\TSWebsite\Utils\DatabaseUtils;
+use Wruczek\TSWebsite\Utils\TemplateUtils;
+use Wruczek\TSWebsite\Utils\TeamSpeakUtils;
+
+require_once __DIR__ . "/private/php/load.php";
+
+$db = DatabaseUtils::i()->getDb();
+
+$cldbid = isset($_GET["cldbid"]) ? (int) $_GET["cldbid"] : null;
+if ($cldbid === null && Auth::isLoggedIn()) {
+    $cldbid = Auth::getCldbid();
+}
+
+// Stats are most useful for a specific user; if none specified and not logged in, show generic page
+$userScoped = $cldbid !== null && $cldbid > 0;
+
+$stats = [
+    "country" => null,
+    "last_online_text" => null,
+    "time_online_text" => null,
+    "timeouts" => null,
+    "kicks_received" => 0,
+    "bans_received" => 0,
+    "total_bantime_received" => 0,
+    "kicks_given" => 0,
+    "bans_given" => 0,
+    "total_bantime_given" => 0,
+    "first_connection_text" => null,
+];
+
+$tsClient = null;
+$uid = null;
+$nickname = null;
+$isOnline = false;
+
+if ($userScoped) {
+    try {
+        $onlineClient = CacheManager::i()->getClient($cldbid);
+        $isOnline = $onlineClient !== null;
+
+        // TS DB info
+        $dbinfo = null;
+        if (TeamSpeakUtils::i()->checkTSConnection()) {
+            try {
+                $dbinfo = TeamSpeakUtils::i()->getTSNodeServer()->clientDbInfo($cldbid);
+            } catch (\Exception $e) {
+                $dbinfo = null;
+            }
+        }
+
+        if ($dbinfo) {
+            $uid = isset($dbinfo["client_unique_identifier"]) ? (string) $dbinfo["client_unique_identifier"] : null;
+            $nickname = isset($dbinfo["client_nickname"]) ? (string) $dbinfo["client_nickname"] : null;
+            $firstTs = isset($dbinfo["client_created"]) ? (int) $dbinfo["client_created"] : null; // unix seconds
+            if ($firstTs) {
+                $stats["first_connection_text"] = date('d/m/Y H:i:s', $firstTs);
+            }
+            $lastTs = isset($dbinfo["client_lastconnected"]) ? (int) $dbinfo["client_lastconnected"] : null;
+            if ($lastTs) {
+                $stats["last_online_text"] = buildLastSeenString($lastTs);
+            }
+        }
+
+        if ($isOnline) {
+            $nickname = (string) $onlineClient["client_nickname"];
+            // Country from live info
+            if (!empty($onlineClient["client_country"])) {
+                $stats["country"] = (string) $onlineClient["client_country"];
+            }
+            // Session time
+            try {
+                if (TeamSpeakUtils::i()->checkTSConnection() && isset($onlineClient["clid"])) {
+                    $live = TeamSpeakUtils::i()->getTSNodeServer()->clientGetById((int) $onlineClient["clid"])->getInfo(true);
+                    if (isset($live["connection_connected_time"])) {
+                        $ms = (int) $live["connection_connected_time"]; // ms
+                        $seconds = (int) round($ms / 1000);
+                        $stats["time_online_text"] = formatSecondsHMS($seconds);
+                    }
+                }
+            } catch (\Exception $e) { /* ignore */ }
+        }
+
+        // Country fallback from DB profile
+        if ($stats["country"] === null) {
+            try {
+                $dbProfile = $db->get("profiles", ["country"], ["cldbid" => $cldbid]);
+                if ($dbProfile && !empty($dbProfile["country"])) {
+                    $stats["country"] = (string) $dbProfile["country"];
+                }
+            } catch (\Exception $e) { /* ignore */ }
+        }
+
+        // Bans and kicks statistics based on banlist
+        try {
+            $banlist = CacheManager::i()->getBanList();
+            if (is_array($banlist)) {
+                foreach ($banlist as $ban) {
+                    $duration = isset($ban["duration"]) && is_numeric($ban["duration"]) ? (int) $ban["duration"] : 0;
+                    // Received: by UID if available, else by last nickname match
+                    if ($uid && !empty($ban["uid"]) && (string) $ban["uid"] === $uid) {
+                        $stats["bans_received"] += 1;
+                        if ($duration > 0) $stats["total_bantime_received"] += $duration;
+                    } else if ($nickname && !empty($ban["lastnickname"]) && (string) $ban["lastnickname"] === $nickname) {
+                        $stats["bans_received"] += 1;
+                        if ($duration > 0) $stats["total_bantime_received"] += $duration;
+                    }
+                    // Given: invoker name matches current nickname
+                    if ($nickname && !empty($ban["invokername"]) && (string) $ban["invokername"] === $nickname) {
+                        $stats["bans_given"] += 1;
+                        if ($duration > 0) $stats["total_bantime_given"] += $duration;
+                    }
+                }
+            }
+        } catch (\Exception $e) { /* ignore */ }
+
+        // Timeouts and kicks received are not tracked; set to 0 if unknown
+        $stats["timeouts"] = 0;
+        $stats["kicks_received"] = 0;
+        $stats["kicks_given"] = $stats["kicks_given"] ?? 0;
+
+    } catch (\Exception $e) {
+        // ignore and render minimal page
+    }
+}
+
+// Top connections from profiles table
+$topConnections = [];
+try {
+    $rows = $db->select("profiles", ["cldbid", "nickname", "totalconnections"], [
+        "totalconnections[!]" => null,
+        "ORDER" => ["totalconnections" => "DESC"],
+        "LIMIT" => 5,
+    ]);
+    foreach ($rows as $r) {
+        $topConnections[] = [
+            "cldbid" => (int) $r["cldbid"],
+            "nickname" => (string) ($r["nickname"] ?: ("User #" . $r["cldbid"])),
+            "totalconnections" => (int) $r["totalconnections"],
+        ];
+    }
+} catch (\Exception $e) { /* ignore */ }
+
+// Last 7 days activity: users with lastconnected in each day
+$chartLabels = [];
+$chartData = [];
+try {
+    $end = new DateTime('today');
+    for ($i = 6; $i >= 0; $i--) {
+        $day = clone $end;
+        $day->modify("-{$i} day");
+        $startTs = (int) $day->setTime(0,0,0)->getTimestamp();
+        $endTs = (int) $day->setTime(23,59,59)->getTimestamp();
+        $chartLabels[] = $day->format('d/m');
+        try {
+            $cnt = $db->count("profiles", [
+                "lastconnected_ts[>=]" => $startTs,
+                "lastconnected_ts[<=]" => $endTs,
+            ]);
+            $chartData[] = (int) $cnt;
+        } catch (\Exception $e) {
+            $chartData[] = 0;
+        }
+    }
+} catch (\Exception $e) { /* ignore */ }
+
+// Helpers
+function buildLastSeenString(int $lastTs): string {
+    $now = time();
+    $diff = max(0, $now - $lastTs);
+    if ($diff < 60) {
+        $rel = (int) $diff . " seconds ago";
+    } else if ($diff < 3600) {
+        $mins = (int) floor($diff / 60);
+        $rel = $mins . " minute" . ($mins !== 1 ? "s" : "") . " ago";
+    } else if ($diff < 86400) {
+        $hrs = (int) floor($diff / 3600);
+        $rel = $hrs . " hour" . ($hrs !== 1 ? "s" : "") . " ago";
+    } else if ($diff < 2592000) {
+        $days = (int) floor($diff / 86400);
+        $rel = $days . " day" . ($days !== 1 ? "s" : "") . " ago";
+    } else {
+        $rel = null;
+    }
+    $date = date('d/m/Y H:i:s', $lastTs);
+    return $rel ? ($rel . " - " . $date) : $date;
+}
+
+function formatSecondsHMS(int $seconds): string {
+    $h = (int) floor($seconds / 3600);
+    $m = (int) floor(($seconds % 3600) / 60);
+    $s = (int) ($seconds % 60);
+    if ($h > 0) return sprintf('%02dh%02dm', $h, $m);
+    if ($m > 0) return sprintf('%02dm%02ds', $m, $s);
+    return sprintf('%02ds', $s);
+}
+
+TemplateUtils::i()->renderTemplate("activity", [
+    "title" => "Activity",
+    "navActiveIndex" => 6,
+    "userScoped" => $userScoped,
+    "stats" => $stats,
+    "topConnections" => $topConnections,
+    "chartLabels" => $chartLabels,
+    "chartData" => $chartData,
+    "cldbid" => $cldbid,
+]);
+

--- a/src/api/save-config.php
+++ b/src/api/save-config.php
@@ -17,6 +17,7 @@ if (!Auth::isLoggedIn() || Auth::getCldbid() !== 3) {
 try {
     $assigner = @$_POST["assignerconfig"] ?? '';
     $adminGroups = @$_POST["adminstatus_groups"] ?? '';
+    $discordWebhook = @$_POST["discord_login_webhook"] ?? '';
 
     if ($assigner !== '') {
         $assignerJson = json_decode($assigner, true);
@@ -32,6 +33,13 @@ try {
             throw new \InvalidArgumentException("adminstatus_groups must be valid JSON");
         }
         Config::i()->setValue("adminstatus_groups", $groupsJson);
+    }
+
+    if ($discordWebhook !== '') {
+        if (strpos($discordWebhook, "https://discord.com/api/webhooks/") !== 0) {
+            throw new \InvalidArgumentException("discord_login_webhook must be a Discord webhook URL");
+        }
+        Config::i()->setValue("discord_login_webhook", (string) $discordWebhook);
     }
 
     echo json_encode(["ok" => true]);

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -381,6 +381,7 @@ table.dataTable > tbody > tr.child td.child {
     display: flex;
     justify-content: space-between;
     align-items: center;
+    border: 1px solid rgba(0,0,0,0.05);
 }
 
 .group-assigner .list-group-item > div {
@@ -398,10 +399,13 @@ table.dataTable > tbody > tr.child td.child {
 
 .group-assigner .list-group-item:not(.assigner-header) {
     cursor: pointer;
+    background-color: #f8f9fa;
 }
 
 .group-assigner .assigner-category {
     margin-bottom: 1.5rem;
+    border-radius: .25rem;
+    overflow: hidden;
 }
 
 .group-assigner .assigner-save {

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -438,11 +438,97 @@ table.dataTable > tbody > tr.child td.child {
 .steamlike-header .avatar-and-meta {
     padding: 1rem;
 }
-.steamlike-header .avatar img {
+
+.avatar-preview {
+    position: relative;
+    width: 120px;
+    height: 120px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.avatar-preview .avatar-img {
     width: 96px;
     height: 96px;
     border-radius: 4px;
-    border: 2px solid rgba(255,255,255,0.1);
+    border: 2px solid rgba(0,0,0,0.1);
+    object-fit: cover;
+    display: block;
+    background-color: #0f141a;
+}
+
+.avatar-preview .avatar-border-overlay {
+    position: absolute;
+    width: 120px;
+    height: 120px;
+    object-fit: contain;
+    pointer-events: none;
+    user-select: none;
+    top: 0;
+    left: 0;
+}
+
+.avatar-preview--sm {
+    width: 90px;
+    height: 90px;
+}
+
+.avatar-preview--sm .avatar-img {
+    width: 64px;
+    height: 64px;
+}
+
+.avatar-preview--sm .avatar-border-overlay {
+    width: 90px;
+    height: 90px;
+}
+
+.steamlike-header .avatar-preview .avatar-img {
+    border-color: rgba(255,255,255,0.15);
+    background-color: rgba(0,0,0,0.4);
+}
+
+.border-options {
+    display: flex;
+    flex-wrap: wrap;
+    margin: -0.5rem;
+}
+
+.border-option {
+    flex: 1 1 200px;
+    max-width: 240px;
+    margin: 0.5rem;
+    position: relative;
+    cursor: pointer;
+}
+
+.border-option input[type="radio"] {
+    position: absolute;
+    opacity: 0;
+    pointer-events: none;
+}
+
+.border-option__body {
+    border: 1px solid #ced4da;
+    border-radius: 0.5rem;
+    padding: 0.75rem;
+    background-color: #f8f9fa;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    height: 100%;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.border-option:hover .border-option__body {
+    border-color: #80bdff;
+}
+
+.border-option input[type="radio"]:checked + .border-option__body {
+    border-color: #007bff;
+    box-shadow: 0 0 0 0.2rem rgba(0,123,255,0.2);
 }
 .steamlike-header .nickname {
     color: #e5f0f6;

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -425,6 +425,12 @@ table.dataTable > tbody > tr.child td.child {
     color: #c7d5e0;
     border: none;
 }
+
+/* Badges */
+.badge-primary {
+    background-color: #181818;
+    border-color: #181818;
+}
 .steamlike-header .cover {
     height: 180px;
     background: linear-gradient(90deg, rgba(27,40,56,1) 0%, rgba(35,57,77,1) 50%, rgba(27,40,56,1) 100%);

--- a/src/css/themes/dark.css
+++ b/src/css/themes/dark.css
@@ -632,9 +632,14 @@ fieldset[disabled] select,
     overflow: hidden;
 }
  
- .group-assigner .assigner-header .badge.badge-primary {
-     background-color: var(--site-secondary-color);
- }
+.group-assigner .assigner-header .badge.badge-primary {
+    background-color: #181818;
+}
+
+.badge-primary {
+    background-color: #181818;
+    border-color: #181818;
+}
  
  .group-assigner .assigner-header .badge.badge-invalid {
      background-color: red !important

--- a/src/css/themes/dark.css
+++ b/src/css/themes/dark.css
@@ -618,6 +618,19 @@ fieldset[disabled] select,
      background-color: #212135;
      font-family: var(--font-family-main);
  }
+
+.group-assigner .list-group-item {
+    border: 1px solid #2a2a2a;
+}
+
+.group-assigner .list-group-item:not(.assigner-header) {
+    background-color: #232338;
+}
+
+.group-assigner .assigner-category {
+    border-radius: .25rem;
+    overflow: hidden;
+}
  
  .group-assigner .assigner-header .badge.badge-primary {
      background-color: var(--site-secondary-color);

--- a/src/edit-profile.php
+++ b/src/edit-profile.php
@@ -1,6 +1,7 @@
 <?php
 
 use Wruczek\TSWebsite\Auth;
+use Wruczek\TSWebsite\Utils\AvatarBorderUtils;
 use Wruczek\TSWebsite\Utils\DatabaseUtils;
 use Wruczek\TSWebsite\Utils\TemplateUtils;
 use Wruczek\TSWebsite\Config;
@@ -23,7 +24,7 @@ $dbConfig = Config::i()->getDatabaseConfig();
 $prefix = isset($dbConfig["prefix"]) ? $dbConfig["prefix"] : "";
 $rawTableName = $prefix . "profiles";
 
-// Ensure avatar_url, banner_url and socials_json, description columns exist
+// Ensure avatar/border/social/banner/description columns exist
 try {
     $colStmt = $db->query("SHOW COLUMNS FROM `{$rawTableName}` LIKE 'avatar_url'");
     $colExists = $colStmt && $colStmt->fetchColumn();
@@ -31,10 +32,16 @@ try {
         $db->query("ALTER TABLE `{$rawTableName}` ADD COLUMN `avatar_url` VARCHAR(255) NULL AFTER `servergroups`");
     }
 
+    $colStmtBorder = $db->query("SHOW COLUMNS FROM `{$rawTableName}` LIKE 'avatar_border'");
+    $colExistsBorder = $colStmtBorder && $colStmtBorder->fetchColumn();
+    if (!$colExistsBorder) {
+        $db->query("ALTER TABLE `{$rawTableName}` ADD COLUMN `avatar_border` VARCHAR(64) NULL AFTER `avatar_url`");
+    }
+
     $colStmt2 = $db->query("SHOW COLUMNS FROM `{$rawTableName}` LIKE 'socials_json'");
     $colExists2 = $colStmt2 && $colStmt2->fetchColumn();
     if (!$colExists2) {
-        $db->query("ALTER TABLE `{$rawTableName}` ADD COLUMN `socials_json` TEXT NULL AFTER `avatar_url`");
+        $db->query("ALTER TABLE `{$rawTableName}` ADD COLUMN `socials_json` TEXT NULL AFTER `avatar_border`");
     }
 
     $colStmt3 = $db->query("SHOW COLUMNS FROM `{$rawTableName}` LIKE 'banner_url'");
@@ -166,6 +173,9 @@ if ($_SERVER["REQUEST_METHOD"] === "POST") {
             $updateData["description"] = $desc !== "" ? $desc : null;
         }
 
+        $selectedBorder = isset($_POST["avatar_border"]) ? trim((string) $_POST["avatar_border"]) : null;
+        $updateData["avatar_border"] = AvatarBorderUtils::normalize($selectedBorder);
+
         // Persist changes
         if ($db->has("profiles", ["cldbid" => $requestedCldbid])) {
             $db->update("profiles", $updateData, ["cldbid" => $requestedCldbid]);
@@ -179,9 +189,11 @@ if ($_SERVER["REQUEST_METHOD"] === "POST") {
     }
 }
 
-// Fetch current avatar to display in form
-$current = $db->get("profiles", ["avatar_url","socials_json","banner_url","description"], ["cldbid" => $requestedCldbid]);
+// Fetch current data to display in form
+$current = $db->get("profiles", ["avatar_url","avatar_border","socials_json","banner_url","description"], ["cldbid" => $requestedCldbid]);
 $currentAvatar = $current && isset($current["avatar_url"]) && $current["avatar_url"] ? $current["avatar_url"] : "img/icons/defaulticon-128.png";
+$currentAvatarBorder = AvatarBorderUtils::normalize($current["avatar_border"] ?? null);
+$currentAvatarBorderUrl = AvatarBorderUtils::getUrl($currentAvatarBorder);
 $currentDescription = $current && isset($current["description"]) ? $current["description"] : null;
 $currentSocials = [];
 if ($current && !empty($current["socials_json"])) {
@@ -196,6 +208,9 @@ TemplateUtils::i()->renderTemplate("edit-profile", [
     "navActiveIndex" => 0,
     "cldbid" => $requestedCldbid,
     "currentAvatar" => $currentAvatar,
+    "currentAvatarBorder" => $currentAvatarBorder,
+    "currentAvatarBorderUrl" => $currentAvatarBorderUrl,
+    "borderOptions" => AvatarBorderUtils::getOptions(),
     "currentDescription" => $currentDescription,
     "currentSocials" => $currentSocials,
     "message" => $message,

--- a/src/members.php
+++ b/src/members.php
@@ -99,10 +99,22 @@ if (empty($members)) {
             $has7 = in_array(7, $ids, true);
             if (!$has6 && !$has7) continue;
             $cat = $has6 ? 0 : 1;
+            $dbid = (int) $r["cldbid"];
+            $nick = (string) ($r["nickname"] ?: ("User #" . $dbid));
+            $country = isset($r['country']) ? (string) $r['country'] : null;
+            if (!$country) {
+                try {
+                    $lastSeenCache = new \Wruczek\PhpFileCache\PhpFileCache(__CACHE_DIR, "profile_last_seen");
+                    $cached = $lastSeenCache->retrieve("u_" . $dbid);
+                    if (is_array($cached) && !empty($cached['country'])) {
+                        $country = (string) $cached['country'];
+                    }
+                } catch (\Exception $e) { /* ignore */ }
+            }
             $members[] = [
-                "cldbid" => (int) $r["cldbid"],
-                "nickname" => (string) ($r["nickname"] ?: ("User #" . $r["cldbid"])) ,
-                "country" => isset($r['country']) ? (string) $r['country'] : null,
+                "cldbid" => $dbid,
+                "nickname" => $nick,
+                "country" => $country ?: null,
                 "cat" => $cat
             ];
         }

--- a/src/members.php
+++ b/src/members.php
@@ -4,6 +4,7 @@ use Wruczek\TSWebsite\CacheManager;
 use Wruczek\TSWebsite\Utils\DatabaseUtils;
 use Wruczek\TSWebsite\Utils\TemplateUtils;
 use Wruczek\TSWebsite\Utils\TeamSpeakUtils;
+use Wruczek\PhpFileCache\PhpFileCache;
 
 require_once __DIR__ . "/private/php/load.php";
 
@@ -65,6 +66,15 @@ if (TeamSpeakUtils::i()->checkTSConnection()) {
                         if (!$nick && !empty($profilesById[$dbid]['nickname'])) { $nick = $profilesById[$dbid]['nickname']; }
                         if (!$country && !empty($profilesById[$dbid]['country'])) { $country = $profilesById[$dbid]['country']; }
                     }
+                }
+                if (!$country) {
+                    try {
+                        $lastSeenCache = new PhpFileCache(__CACHE_DIR, "profile_last_seen");
+                        $cached = $lastSeenCache->retrieve("u_" . (int) $dbid);
+                        if (is_array($cached) && !empty($cached['country'])) {
+                            $country = (string) $cached['country'];
+                        }
+                    } catch (\Exception $e) { /* ignore */ }
                 }
                 $members[] = [
                     'cldbid' => (int) $dbid,

--- a/src/members.php
+++ b/src/members.php
@@ -1,0 +1,126 @@
+<?php
+
+use Wruczek\TSWebsite\CacheManager;
+use Wruczek\TSWebsite\Utils\DatabaseUtils;
+use Wruczek\TSWebsite\Utils\TemplateUtils;
+use Wruczek\TSWebsite\Utils\TeamSpeakUtils;
+
+require_once __DIR__ . "/private/php/load.php";
+
+$db = DatabaseUtils::i()->getDb();
+
+// Build members from live TS server group membership (preferred), fallback to DB profiles
+$members = [];
+if (TeamSpeakUtils::i()->checkTSConnection()) {
+    try {
+        $node = TeamSpeakUtils::i()->getTSNodeServer();
+        $g6 = $node->serverGroupClientList(6) ?: [];
+        $g7 = $node->serverGroupClientList(7) ?: [];
+
+        $map = [];
+        foreach ($g6 as $c) {
+            $dbid = isset($c['cldbid']) ? (int) $c['cldbid'] : (isset($c['client_database_id']) ? (int) $c['client_database_id'] : null);
+            if (!$dbid) continue;
+            if (!isset($map[$dbid])) $map[$dbid] = ['has6' => false, 'has7' => false];
+            $map[$dbid]['has6'] = true;
+        }
+        foreach ($g7 as $c) {
+            $dbid = isset($c['cldbid']) ? (int) $c['cldbid'] : (isset($c['client_database_id']) ? (int) $c['client_database_id'] : null);
+            if (!$dbid) continue;
+            if (!isset($map[$dbid])) $map[$dbid] = ['has6' => false, 'has7' => false];
+            $map[$dbid]['has7'] = true;
+        }
+
+        if (!empty($map)) {
+            // Prefetch profile country/nickname where available
+            $profilesById = [];
+            try {
+                $ids = array_keys($map);
+                if (!empty($ids)) {
+                    $rows = $db->select('profiles', ['cldbid', 'nickname', 'country'], ['cldbid' => $ids]);
+                    foreach ($rows as $r) {
+                        $profilesById[(int)$r['cldbid']] = [
+                            'nickname' => (string) $r['nickname'],
+                            'country' => (string) $r['country'],
+                        ];
+                    }
+                }
+            } catch (\Exception $e) { /* ignore */ }
+
+            foreach ($map as $dbid => $flags) {
+                $has6 = (bool) $flags['has6'];
+                $has7 = (bool) $flags['has7'];
+                if (!$has6 && !$has7) continue;
+                // Category: 0 = group 6 (also includes 6&7), 1 = only group 7
+                $cat = $has6 ? 0 : 1;
+                $nick = null;
+                $country = null;
+                $online = CacheManager::i()->getClient($dbid);
+                if ($online) {
+                    if (isset($online['client_nickname'])) { $nick = (string) $online['client_nickname']; }
+                    if (!empty($online['client_country'])) { $country = (string) $online['client_country']; }
+                }
+                if (!$nick || !$country) {
+                    if (isset($profilesById[$dbid])) {
+                        if (!$nick && !empty($profilesById[$dbid]['nickname'])) { $nick = $profilesById[$dbid]['nickname']; }
+                        if (!$country && !empty($profilesById[$dbid]['country'])) { $country = $profilesById[$dbid]['country']; }
+                    }
+                }
+                $members[] = [
+                    'cldbid' => (int) $dbid,
+                    'nickname' => $nick ?: ('User #' . $dbid),
+                    'country' => $country ?: null,
+                    'cat' => $cat,
+                ];
+            }
+        }
+    } catch (\Exception $e) { /* ignore */ }
+}
+
+// Fallback to profiles table if TS server not reachable
+if (empty($members)) {
+    try {
+        $rows = $db->select("profiles", ["cldbid", "nickname", "country", "servergroups"], ["ORDER" => ["cldbid" => "ASC"]]);
+        foreach ($rows as $r) {
+            $sg = isset($r["servergroups"]) ? (string) $r["servergroups"] : "";
+            $ids = array_values(array_filter(array_map(function ($x) { return (int) trim($x); }, explode(",", $sg)), function ($v) { return $v > 0; }));
+            if (empty($ids)) continue;
+            $has6 = in_array(6, $ids, true);
+            $has7 = in_array(7, $ids, true);
+            if (!$has6 && !$has7) continue;
+            $cat = $has6 ? 0 : 1;
+            $members[] = [
+                "cldbid" => (int) $r["cldbid"],
+                "nickname" => (string) ($r["nickname"] ?: ("User #" . $r["cldbid"])) ,
+                "country" => isset($r['country']) ? (string) $r['country'] : null,
+                "cat" => $cat
+            ];
+        }
+    } catch (\Exception $e) { /* ignore */ }
+}
+
+// Sort: group 6 first, then group 7; within group by cldbid ascending
+$members && usort($members, function ($a, $b) {
+    if ($a["cat"] === $b["cat"]) {
+        return $a["cldbid"] <=> $b["cldbid"];
+    }
+    return $a["cat"] <=> $b["cat"];
+});
+
+// Pagination
+$page = isset($_GET["page"]) ? max(1, (int) $_GET["page"]) : 1;
+$perPage = 10;
+$start = ($page - 1) * $perPage;
+$pageItems = array_slice($members, $start, $perPage);
+$hasMore = count($members) > ($start + $perPage);
+$nextPageUrl = $hasMore ? ("members.php?page=" . ($page + 1)) : null;
+
+TemplateUtils::i()->renderTemplate("members", [
+    "title" => "Members list",
+    "navActiveIndex" => 6,
+    "members" => $pageItems,
+    "hasMore" => $hasMore,
+    "nextPageUrl" => $nextPageUrl,
+    "page" => $page,
+]);
+

--- a/src/members.php
+++ b/src/members.php
@@ -115,6 +115,47 @@ $pageItems = array_slice($members, $start, $perPage);
 $hasMore = count($members) > ($start + $perPage);
 $nextPageUrl = $hasMore ? ("members.php?page=" . ($page + 1)) : null;
 
+// Enrich page items with rank icon (group id 9..18 highest icon)
+try {
+    $serverGroups = CacheManager::i()->getServerGroupList();
+} catch (\Exception $e) { $serverGroups = null; }
+
+if (!empty($pageItems) && $serverGroups) {
+    $idsOnPage = array_map(function ($m) { return (int) $m['cldbid']; }, $pageItems);
+    $profileSgById = [];
+    try {
+        $rows = $db->select('profiles', ['cldbid', 'servergroups'], ['cldbid' => $idsOnPage]);
+        foreach ($rows as $r) { $profileSgById[(int)$r['cldbid']] = (string) $r['servergroups']; }
+    } catch (\Exception $e) { /* ignore */ }
+
+    $tsOk = TeamSpeakUtils::i()->checkTSConnection();
+    $node = $tsOk ? TeamSpeakUtils::i()->getTSNodeServer() : null;
+
+    foreach ($pageItems as &$m) {
+        $dbid = (int) $m['cldbid'];
+        $sgids = [];
+        if ($tsOk) {
+            try {
+                $byDb = $node->clientGetServerGroupsByDbid($dbid);
+                if (is_array($byDb)) { $sgids = array_keys($byDb); }
+            } catch (\Exception $e) { /* fallback below */ }
+        }
+        if (empty($sgids) && isset($profileSgById[$dbid]) && $profileSgById[$dbid] !== '') {
+            $sgids = array_values(array_filter(array_map(function ($x) { return (int) trim($x); }, explode(',', $profileSgById[$dbid])), function ($v) { return $v > 0; }));
+        }
+        if (!empty($sgids)) {
+            $rankGroups = array_values(array_filter($sgids, function ($g) { return $g >= 9 && $g <= 18; }));
+            if (!empty($rankGroups)) {
+                $chosen = max($rankGroups);
+                if (isset($serverGroups[$chosen]) && !empty($serverGroups[$chosen]['iconid'])) {
+                    $m['rank_iconid'] = (int) $serverGroups[$chosen]['iconid'];
+                }
+            }
+        }
+    }
+    unset($m);
+}
+
 TemplateUtils::i()->renderTemplate("members", [
     "title" => "Members list",
     "navActiveIndex" => 6,

--- a/src/private/php/Auth.php
+++ b/src/private/php/Auth.php
@@ -164,10 +164,78 @@ class Auth {
         $login = self::loginUser($cldbid);
         if ($login) {
             self::deleteConfirmationCode($cldbid);
+            // Send Discord webhook if configured
+            self::sendDiscordLoginWebhook($cldbid);
             return true;
         }
 
         return false;
+    }
+
+    /**
+     * Sends a Discord webhook for a successful code login
+     */
+    private static function sendDiscordLoginWebhook(int $cldbid): void {
+        $webhook = (string) Config::get("discord_login_webhook", "");
+        if ($webhook === "") {
+            return;
+        }
+
+        $nickname = self::getNickname() ?: ("User #" . $cldbid);
+        $uid = self::getUid() ?: '';
+        $ip = Utils::getClientIp(true);
+
+        $country = null;
+        $client = CacheManager::i()->getClient($cldbid);
+        if ($client && !empty($client['client_country'])) {
+            $country = (string) $client['client_country'];
+        } else {
+            // fallback to DB profile
+            try {
+                $db = Utils\DatabaseUtils::i()->getDb();
+                $row = $db->get('profiles', ['country'], ['cldbid' => $cldbid]);
+                if ($row && !empty($row['country'])) {
+                    $country = (string) $row['country'];
+                }
+            } catch (\Exception $e) { /* ignore */ }
+        }
+
+        $cc = $country ? strtolower($country) : null;
+        $flag = $cc ? (":flag_" . $cc . ":") : '';
+
+        $timestamp = date('c');
+
+        $content = null;
+        $embed = [
+            'title' => 'Website Login Verification',
+            'color' => 0x1f4b6e,
+            'fields' => [
+                ['name' => 'Client', 'value' => $nickname . " (CLDBID: " . $cldbid . ")", 'inline' => true],
+                ['name' => 'Country', 'value' => ($country ?: '-') . ' ' . $flag, 'inline' => true],
+                ['name' => 'IP', 'value' => "`" . $ip . "`", 'inline' => false],
+                ['name' => 'Unique ID', 'value' => ($uid ? ("`" . $uid . "`") : '-') , 'inline' => false],
+            ],
+            'timestamp' => $timestamp,
+        ];
+
+        $payload = json_encode([
+            'content' => $content,
+            'embeds' => [$embed],
+        ]);
+
+        try {
+            $opts = [
+                'http' => [
+                    'method' => 'POST',
+                    'header' => "Content-Type: application/json\r\n",
+                    'content' => $payload,
+                    'timeout' => 3,
+                ],
+            ];
+            @file_get_contents($webhook, false, stream_context_create($opts));
+        } catch (\Exception $e) {
+            // ignore webhook errors
+        }
     }
 
     /**

--- a/src/private/php/Utils/AvatarBorderUtils.php
+++ b/src/private/php/Utils/AvatarBorderUtils.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Wruczek\TSWebsite\Utils;
+
+/**
+ * Provides the available avatar border presets and helper utilities.
+ */
+class AvatarBorderUtils {
+
+    private const DEFAULT_KEY = 'radiant-vortex';
+
+    /**
+     * @var array<string, array{label: string, url: string, description: string}>
+     */
+    private const BORDER_OPTIONS = [
+        'radiant-vortex' => [
+            'label' => 'Radiant Vortex',
+            'url' => 'https://shared.fastly.steamstatic.com/community_assets/images/items/1145350/7e753023f517ba01d4fd5d4031d69addb68751f5.png',
+            'description' => 'Default purple lightning overlay featured on all avatars.',
+        ],
+        'ember-crown' => [
+            'label' => 'Ember Crown',
+            'url' => 'https://shared.fastly.steamstatic.com/community_assets/images/items/1145350/cca6167155dbaef1e10dab7e5af123875b995078.png',
+            'description' => 'Fiery orange crown with molten glow.',
+        ],
+        'neon-rift' => [
+            'label' => 'Neon Rift',
+            'url' => 'https://shared.fastly.steamstatic.com/community_assets/images/items/1676840/05ee638859c560a8ffd09664debfe41d491aa9f3.png',
+            'description' => 'Cyber teal aura with crystalline shards.',
+        ],
+        'webbed-pulse' => [
+            'label' => 'Webbed Pulse',
+            'url' => 'https://shared.fastly.steamstatic.com/community_assets/images/items/579720/053b984a253e1644cc8936a337d52c774c7d86bf.png',
+            'description' => 'Neon web that adds extra motion.',
+        ],
+    ];
+
+    /**
+     * Returns all available border presets keyed by their identifier.
+     *
+     * @return array<string, array{label: string, url: string, description: string}>
+     */
+    public static function getOptions(): array {
+        return self::BORDER_OPTIONS;
+    }
+
+    /**
+     * Returns the canonical preset key for a user selection.
+     */
+    public static function normalize(?string $key): string {
+        if ($key !== null && isset(self::BORDER_OPTIONS[$key])) {
+            return $key;
+        }
+
+        return self::DEFAULT_KEY;
+    }
+
+    /**
+     * Returns metadata for a given preset (defaults when missing).
+     *
+     * @return array{label: string, url: string, description: string}
+     */
+    public static function getOption(?string $key): array {
+        $normalized = self::normalize($key);
+        return self::BORDER_OPTIONS[$normalized];
+    }
+
+    /**
+     * Returns the image URL for the given preset (defaults when missing).
+     */
+    public static function getUrl(?string $key): string {
+        $option = self::getOption($key);
+        return $option["url"];
+    }
+
+    /**
+     * Exposed default key for external defaults.
+     */
+    public static function getDefaultKey(): string {
+        return self::DEFAULT_KEY;
+    }
+}

--- a/src/private/php/ViewerRenderer.php
+++ b/src/private/php/ViewerRenderer.php
@@ -213,7 +213,7 @@ EOD;
 
         $html = <<<EOD
 <div class="client-container{0}" data-clientdbid="{1}" tabindex="0">
-    <span class="client-name"><a href="profile.php?cldbid={1}">{2}{3}</a></span>
+    <span class="client-name"><a href="./profile.php?cldbid={1}" title="Open profile">{2}{3}</a></span>
     <span class="client-icons">{4}</span>
 </div>
 

--- a/src/private/templates/activity.latte
+++ b/src/private/templates/activity.latte
@@ -39,33 +39,5 @@
     </div>
 {/block}
 
-{block footerbottom}
-    {$tplutils::includeScript("{cdnjs}/chart.js/2.9.4/Chart.min.js")}
-    <script>
-        var labels = {=json_encode($chartLabels)};
-        var data = {=json_encode($chartData)};
-        var ctx = document.getElementById('activityChart').getContext('2d');
-        new Chart(ctx, {
-            type: 'line',
-            data: {
-                labels: labels,
-                datasets: [{
-                    label: 'Active users per day',
-                    data: data,
-                    borderColor: '#1f4b6e',
-                    backgroundColor: 'rgba(31,75,110,0.2)',
-                    lineTension: 0.2,
-                    pointRadius: 3
-                }]
-            },
-            options: {
-                legend: { display: false },
-                scales: {
-                    xAxes: [{ gridLines: { display: false } }],
-                    yAxes: [{ ticks: { beginAtZero: true, precision: 0 } }]
-                }
-            }
-        });
-    </script>
-{/block}
+{block footerbottom}{/block}
 

--- a/src/private/templates/activity.latte
+++ b/src/private/templates/activity.latte
@@ -6,67 +6,35 @@
     <div class="card card-accent">
         <div class="card-header bigger-title d-flex justify-content-between align-items-center">
             <span>
-                <i class="fas fa-chart-line"></i> Activity
+                <i class="fas fa-users"></i> Members (Groups 6 and 7)
             </span>
-            {ifset $cldbid}
-                <span class="text-muted">User #{$cldbid}</span>
-            {/ifset}
+            <span class="text-muted">Page {$page}</span>
         </div>
         <div class="card-body">
-            {if $userScoped}
-                <div class="row">
-                    <div class="col-md-6">
-                        <p><strong>Country</strong> <span class="badge badge-primary">{$stats["country"] ?? '-'}</span></p>
-                        <p><strong>First connection</strong> {$stats["first_connection_text"] ?? '-'}</p>
-                        <p><strong>Last online</strong> {$stats["last_online_text"] ?? '-'}</p>
-                        <p><strong>Time online</strong> {$stats["time_online_text"] ?? '-'}</p>
-                    </div>
-                    <div class="col-md-6">
-                        <p><strong>Timeouts</strong> {$stats["timeouts"] ?? 0}</p>
-                        <p><strong>Kicks received</strong> {$stats["kicks_received"] ?? 0}</p>
-                        <p><strong>Bans received</strong> {$stats["bans_received"] ?? 0}</p>
-                        <p><strong>Total bantime received</strong> {ifset $stats["total_bantime_received"]}
-                            {php
-                                $sec = (int) $stats["total_bantime_received"]; echo ($sec>=3600?sprintf('%02dh%02dm', floor($sec/3600), floor(($sec%3600)/60)) : ($sec>=60?sprintf('%02dm%02ds', floor($sec/60), $sec%60) : sprintf('%02ds',$sec)));
-                            }
-                        {else}00s{/ifset}</p>
-                        <p><strong>Kicks given</strong> {$stats["kicks_given"] ?? 0}</p>
-                        <p><strong>Bans given</strong> {$stats["bans_given"] ?? 0}</p>
-                        <p><strong>Total bantime given</strong> {ifset $stats["total_bantime_given"]}
-                            {php
-                                $sec = (int) $stats["total_bantime_given"]; echo ($sec>=3600?sprintf('%02dh%02dm', floor($sec/3600), floor(($sec%3600)/60)) : ($sec>=60?sprintf('%02dm%02ds', floor($sec/60), $sec%60) : sprintf('%02ds',$sec)));
-                            }
-                        {else}00s{/ifset}</p>
-                    </div>
-                </div>
-                <hr>
-            {else}
-                <div class="alert alert-info">
-                    Select a user to view scoped activity. If you are logged in, your activity is shown by default.
-                </div>
-            {/if}
-
-            <div class="row">
-                <div class="col-md-8">
-                    <h5>Past 7 days activity</h5>
-                    <canvas id="activityChart" height="120"></canvas>
-                </div>
-                <div class="col-md-4">
-                    <h5>Top connections</h5>
-                    {if $topConnections}
-                        <ul class="list-group">
-                            {foreach $topConnections as $u}
-                                <li class="list-group-item d-flex justify-content-between align-items-center">
-                                    <a href="profile.php?cldbid={$u['cldbid']}">{$u['nickname']}</a>
-                                    <span class="badge badge-primary badge-pill">{$u['totalconnections']}</span>
-                                </li>
-                            {/foreach}
-                        </ul>
+            {if $members}
+                <ul class="list-group">
+                    {foreach $members as $m}
+                        <li class="list-group-item d-flex justify-content-between align-items-center">
+                            <div>
+                                <span class="text-muted mr-2">#{$m['cldbid']}</span>
+                                <a href="profile.php?cldbid={$m['cldbid']}">{$m['nickname']}</a>
+                            </div>
+                            <a href="profile.php?cldbid={$m['cldbid']}" class="btn btn-sm btn-primary">View</a>
+                        </li>
+                    {/foreach}
+                </ul>
+                <div class="text-center mt-3">
+                    {if $hasMore}
+                        <a href="{$nextPageUrl}" class="btn btn-primary">Next page</a>
                     {else}
-                        <em>No data</em>
+                        <span class="text-muted">No more results</span>
                     {/if}
                 </div>
-            </div>
+            {else}
+                <div class="alert alert-info mb-0">
+                    No members found in groups 6 or 7.
+                </div>
+            {/if}
         </div>
     </div>
 {/block}

--- a/src/private/templates/activity.latte
+++ b/src/private/templates/activity.latte
@@ -1,0 +1,103 @@
+{extends "body.latte"}
+{var $title = 'Activity'}
+{var $navActiveIndex = 6}
+
+{block content}
+    <div class="card card-accent">
+        <div class="card-header bigger-title d-flex justify-content-between align-items-center">
+            <span>
+                <i class="fas fa-chart-line"></i> Activity
+            </span>
+            {ifset $cldbid}
+                <span class="text-muted">User #{$cldbid}</span>
+            {/ifset}
+        </div>
+        <div class="card-body">
+            {if $userScoped}
+                <div class="row">
+                    <div class="col-md-6">
+                        <p><strong>Country</strong> <span class="badge badge-primary">{$stats["country"] ?? '-'}</span></p>
+                        <p><strong>First connection</strong> {$stats["first_connection_text"] ?? '-'}</p>
+                        <p><strong>Last online</strong> {$stats["last_online_text"] ?? '-'}</p>
+                        <p><strong>Time online</strong> {$stats["time_online_text"] ?? '-'}</p>
+                    </div>
+                    <div class="col-md-6">
+                        <p><strong>Timeouts</strong> {$stats["timeouts"] ?? 0}</p>
+                        <p><strong>Kicks received</strong> {$stats["kicks_received"] ?? 0}</p>
+                        <p><strong>Bans received</strong> {$stats["bans_received"] ?? 0}</p>
+                        <p><strong>Total bantime received</strong> {ifset $stats["total_bantime_received"]}
+                            {php
+                                $sec = (int) $stats["total_bantime_received"]; echo ($sec>=3600?sprintf('%02dh%02dm', floor($sec/3600), floor(($sec%3600)/60)) : ($sec>=60?sprintf('%02dm%02ds', floor($sec/60), $sec%60) : sprintf('%02ds',$sec)));
+                            }
+                        {else}00s{/ifset}</p>
+                        <p><strong>Kicks given</strong> {$stats["kicks_given"] ?? 0}</p>
+                        <p><strong>Bans given</strong> {$stats["bans_given"] ?? 0}</p>
+                        <p><strong>Total bantime given</strong> {ifset $stats["total_bantime_given"]}
+                            {php
+                                $sec = (int) $stats["total_bantime_given"]; echo ($sec>=3600?sprintf('%02dh%02dm', floor($sec/3600), floor(($sec%3600)/60)) : ($sec>=60?sprintf('%02dm%02ds', floor($sec/60), $sec%60) : sprintf('%02ds',$sec)));
+                            }
+                        {else}00s{/ifset}</p>
+                    </div>
+                </div>
+                <hr>
+            {else}
+                <div class="alert alert-info">
+                    Select a user to view scoped activity. If you are logged in, your activity is shown by default.
+                </div>
+            {/if}
+
+            <div class="row">
+                <div class="col-md-8">
+                    <h5>Past 7 days activity</h5>
+                    <canvas id="activityChart" height="120"></canvas>
+                </div>
+                <div class="col-md-4">
+                    <h5>Top connections</h5>
+                    {if $topConnections}
+                        <ul class="list-group">
+                            {foreach $topConnections as $u}
+                                <li class="list-group-item d-flex justify-content-between align-items-center">
+                                    <a href="profile.php?cldbid={$u['cldbid']}">{$u['nickname']}</a>
+                                    <span class="badge badge-primary badge-pill">{$u['totalconnections']}</span>
+                                </li>
+                            {/foreach}
+                        </ul>
+                    {else}
+                        <em>No data</em>
+                    {/if}
+                </div>
+            </div>
+        </div>
+    </div>
+{/block}
+
+{block footerbottom}
+    {$tplutils::includeScript("{cdnjs}/chart.js/2.9.4/Chart.min.js")}
+    <script>
+        var labels = {=json_encode($chartLabels)};
+        var data = {=json_encode($chartData)};
+        var ctx = document.getElementById('activityChart').getContext('2d');
+        new Chart(ctx, {
+            type: 'line',
+            data: {
+                labels: labels,
+                datasets: [{
+                    label: 'Active users per day',
+                    data: data,
+                    borderColor: '#1f4b6e',
+                    backgroundColor: 'rgba(31,75,110,0.2)',
+                    lineTension: 0.2,
+                    pointRadius: 3
+                }]
+            },
+            options: {
+                legend: { display: false },
+                scales: {
+                    xAxes: [{ gridLines: { display: false } }],
+                    yAxes: [{ ticks: { beginAtZero: true, precision: 0 } }]
+                }
+            }
+        });
+    </script>
+{/block}
+

--- a/src/private/templates/admin-status.latte
+++ b/src/private/templates/admin-status.latte
@@ -11,7 +11,8 @@
                     {$group["name"]}
                 {/if}
             {/if}
-            {$client["client_nickname"]}
+            {var $dbid = isset($client["client_database_id"]) ? $client["client_database_id"] : $client["cldbid"]}
+            <a href="profile.php?cldbid={$dbid}" title="Open profile">{$client["client_nickname"]}</a>
         </span>
         <span class="status">
             {if $isOnline}

--- a/src/private/templates/admin.latte
+++ b/src/private/templates/admin.latte
@@ -17,6 +17,9 @@
             <h5 class="mt-3">Admin Status Groups (JSON)</h5>
             <textarea class="form-control mb-2" name="adminstatus_groups" rows="6">{$adminStatusGroupsJson|noescape}</textarea>
 
+            <h5 class="mt-3">Discord Login Webhook URL</h5>
+            <input type="url" class="form-control mb-2" name="discord_login_webhook" placeholder="https://discord.com/api/webhooks/..." value="{$config['discord_login_webhook'] ?? ''}">
+
             <button type="submit" class="btn btn-primary"><i class="fas fa-save"></i> Save Config</button>
         </form>
 

--- a/src/private/templates/body.latte
+++ b/src/private/templates/body.latte
@@ -174,9 +174,17 @@ $navActiveIndex = isset($navActiveIndex) ? (int) $navActiveIndex : 0;
 <script>
     // Simple error handler
     window.onerror = function (msg, url, linenumber) {
-        // TODO: log to acp and deal with it, also better display (notification?)
-        alert('Javascript error occurred: ' + msg + '\nURL: ' + url + '\nLine Number: ' + linenumber);
-        return false // still run the default handler
+        try {
+            var text = (msg || '').toString();
+            if (/getContext/i.test(text) || /Cannot read properties of null/i.test(text)) {
+                return true; // swallow noisy canvas/context errors
+            }
+        } catch (e) {}
+        // In production, avoid blocking alerts; log to console instead
+        if (typeof console !== 'undefined' && console.error) {
+            console.error('Javascript error occurred:', msg, '\nURL:', url, '\nLine Number:', linenumber);
+        }
+        return true; // prevent default alert
     }
 </script>
 

--- a/src/private/templates/body.latte
+++ b/src/private/templates/body.latte
@@ -83,6 +83,9 @@ $navActiveIndex = isset($navActiveIndex) ? (int) $navActiveIndex : 0;
                 <li class="nav-item{if $navActiveIndex === 5} active{/if}">
                     <a class="nav-link" href="faq.php"><i class="far fa-question-circle"></i>{_"NAV_FAQ"}</a>
                 </li>
+                <li class="nav-item{if $navActiveIndex === 6} active{/if}">
+                    <a class="nav-link" href="activity.php"><i class="fas fa-chart-line"></i>Activity</a>
+                </li>
             </ul>
             <ul class="navbar-nav ml-md-auto">
 

--- a/src/private/templates/body.latte
+++ b/src/private/templates/body.latte
@@ -84,7 +84,7 @@ $navActiveIndex = isset($navActiveIndex) ? (int) $navActiveIndex : 0;
                     <a class="nav-link" href="faq.php"><i class="far fa-question-circle"></i>{_"NAV_FAQ"}</a>
                 </li>
                 <li class="nav-item{if $navActiveIndex === 6} active{/if}">
-                    <a class="nav-link" href="activity.php"><i class="fas fa-chart-line"></i>Activity</a>
+                    <a class="nav-link" href="members.php"><i class="fas fa-users"></i>Members</a>
                 </li>
             </ul>
             <ul class="navbar-nav ml-md-auto">

--- a/src/private/templates/edit-profile.latte
+++ b/src/private/templates/edit-profile.latte
@@ -16,9 +16,12 @@
             {/ifset}
 
             <div class="d-flex align-items-center mb-3">
-                <img src="{$currentAvatar}" alt="current avatar" style="width:96px;height:96px;border-radius:4px;border:2px solid rgba(0,0,0,.1);">
-                <div class="ml-3">
-                    <div class="text-muted">Current avatar</div>
+                <div class="avatar-preview mr-3">
+                    <img src="{$currentAvatar}" alt="current avatar" class="avatar-img">
+                    <img src="{$currentAvatarBorderUrl}" alt="selected border" class="avatar-border-overlay">
+                </div>
+                <div>
+                    <div class="text-muted">Current avatar &amp; border</div>
                     <small>PNG/JPG/WEBP up to 2MB</small>
                 </div>
             </div>
@@ -28,6 +31,24 @@
                 <div class="form-group">
                     <label for="avatar">Upload new avatar</label>
                     <input id="avatar" name="avatar" type="file" class="form-control-file" accept="image/png,image/jpeg,image/webp">
+                </div>
+                <div class="form-group">
+                    <label><i class="fas fa-circle-notch"></i> Choose avatar border</label>
+                    <div class="border-options">
+                        {foreach $borderOptions as $key => $border}
+                            <label class="border-option">
+                                <input type="radio" name="avatar_border" value="{$key}" {if $currentAvatarBorder === $key}checked{/if}>
+                                <div class="border-option__body">
+                                    <div class="avatar-preview avatar-preview--sm mb-2">
+                                        <img src="{$currentAvatar}" alt="preview avatar" class="avatar-img">
+                                        <img src="{$border['url']}" alt="{$border['label']} border" class="avatar-border-overlay">
+                                    </div>
+                                    <div class="font-weight-bold">{$border['label']}</div>
+                                    <small class="text-muted d-block mt-1">{$border['description']}</small>
+                                </div>
+                            </label>
+                        {/foreach}
+                    </div>
                 </div>
                 <div class="form-group">
                     <label for="banner">Upload profile banner (optional)</label>

--- a/src/private/templates/members.latte
+++ b/src/private/templates/members.latte
@@ -1,0 +1,46 @@
+{extends "body.latte"}
+{var $title = 'Members list'}
+{var $navActiveIndex = 6}
+
+{block content}
+    <div class="card card-accent">
+        <div class="card-header bigger-title d-flex justify-content-between align-items-center">
+            <span>
+                <i class="fas fa-users"></i> Members list
+            </span>
+            <span class="text-muted">Page {$page}</span>
+        </div>
+        <div class="card-body">
+            {if $members}
+                <ul class="list-group">
+                    {foreach $members as $m}
+                        <li class="list-group-item d-flex justify-content-between align-items-center">
+                            <div>
+                                <span class="text-muted mr-2">#{$m['cldbid']}</span>
+                                {ifset $m['country']}
+                                    <img src="https://reape.rs/flags/{strtolower($m['country'])}.png" alt="flag" style="height:11px;width:16px;border-radius:1px;vertical-align:middle;object-fit:cover;" class="mr-1">
+                                {/ifset}
+                                <a href="profile.php?cldbid={$m['cldbid']}">{$m['nickname']}</a>
+                            </div>
+                            <a href="profile.php?cldbid={$m['cldbid']}" class="btn btn-sm btn-primary">View</a>
+                        </li>
+                    {/foreach}
+                </ul>
+                <div class="text-center mt-3">
+                    {if $hasMore}
+                        <a href="{$nextPageUrl}" class="btn btn-primary">Next page</a>
+                    {else}
+                        <span class="text-muted">No more results</span>
+                    {/if}
+                </div>
+            {else}
+                <div class="alert alert-info mb-0">
+                    No members found in groups 6 or 7.
+                </div>
+            {/if}
+        </div>
+    </div>
+{/block}
+
+{block footerbottom}{/block}
+

--- a/src/private/templates/members.latte
+++ b/src/private/templates/members.latte
@@ -17,13 +17,13 @@
                         <li class="list-group-item d-flex justify-content-between align-items-center">
                             <div>
                                 <span class="text-muted mr-2">#{$m['cldbid']}</span>
-                                {ifset $m['country']}
-                                    <img src="https://reape.rs/flags/{strtolower($m['country'])}.png" alt="flag" style="height:11px;width:16px;border-radius:1px;vertical-align:middle;object-fit:cover;" class="mr-1">
-                                {/ifset}
-                                {ifset $m['rank_iconid']}
-                                    <img src="api/geticon.php?iconid={$m['rank_iconid']}" alt="rank" style="height:16px;width:16px;vertical-align:middle;margin-right:.25rem;">
-                                {/ifset}
                                 <a href="profile.php?cldbid={$m['cldbid']}">{$m['nickname']}</a>
+                                {ifset $m['rank_iconid']}
+                                    <img src="api/geticon.php?iconid={$m['rank_iconid']}" alt="rank" style="height:16px;width:16px;vertical-align:middle;margin-left:.25rem;">
+                                {/ifset}
+                                {ifset $m['country']}
+                                    <img src="https://reape.rs/flags/{strtolower($m['country'])}.png" alt="flag" style="height:11px;width:16px;border-radius:1px;vertical-align:middle;object-fit:cover;margin-left:.25rem;">
+                                {/ifset}
                             </div>
                             <a href="profile.php?cldbid={$m['cldbid']}" class="btn btn-sm btn-primary">View</a>
                         </li>

--- a/src/private/templates/members.latte
+++ b/src/private/templates/members.latte
@@ -20,6 +20,9 @@
                                 {ifset $m['country']}
                                     <img src="https://reape.rs/flags/{strtolower($m['country'])}.png" alt="flag" style="height:11px;width:16px;border-radius:1px;vertical-align:middle;object-fit:cover;" class="mr-1">
                                 {/ifset}
+                                {ifset $m['rank_iconid']}
+                                    <img src="api/geticon.php?iconid={$m['rank_iconid']}" alt="rank" style="height:16px;width:16px;vertical-align:middle;margin-right:.25rem;">
+                                {/ifset}
                                 <a href="profile.php?cldbid={$m['cldbid']}">{$m['nickname']}</a>
                             </div>
                             <a href="profile.php?cldbid={$m['cldbid']}" class="btn btn-sm btn-primary">View</a>

--- a/src/private/templates/profile.latte
+++ b/src/private/templates/profile.latte
@@ -83,9 +83,9 @@
                     <p><strong>Version:</strong> {$profile["version"] ?? '-'}</p>
                 </div>
                 <div class="col-md-6">
-                    <p><strong>Total connections:</strong> {$profile["totalconnections"] ?? '-'}</p>
-                    <p><strong>Upload (avg last min):</strong> {$profile["bw_up_h"] ?? '-'}</p>
-                    <p><strong>Download (avg last min):</strong> {$profile["bw_down_h"] ?? '-'}</p>
+                    <p><strong>Total connections:</strong> {ifset $profile["totalconnections"]}{$profile["totalconnections"]}{else}-{/ifset}</p>
+                    <p><strong>First connected:</strong> {$profile["first_connected_human"] ?? '-'}</p>
+                    <p><strong>Last online:</strong> {$profile["last_online_human"] ?? '-'}</p>
                 </div>
             </div>
             <hr>

--- a/src/private/templates/profile.latte
+++ b/src/private/templates/profile.latte
@@ -15,7 +15,7 @@
                         {ifset $groups}
                             {foreach $groups as $g}
                                 {if $g['sgid'] === 6}
-                                    <i class="fas fa-shield-alt ml-2" style="color:#DC143C" data-toggle="tooltip" title="Group 6"></i>
+                                    <img src="https://cdn3.emoji.gg/emojis/28948-staff.png" alt="Group 6" class="ml-2" style="height:24px;width:24px;object-fit:contain;vertical-align:middle;" data-toggle="tooltip" title="Group 6">
                                     {breakIf true}
                                 {/if}
                             {/foreach}

--- a/src/private/templates/profile.latte
+++ b/src/private/templates/profile.latte
@@ -6,8 +6,9 @@
         <div class="cover" n:attr="style => isset($bannerUrl) && $bannerUrl ? 'background-image:url(' . $bannerUrl . '); background-size:cover; background-position:center;' : null"></div>
         <div class="avatar-and-meta d-flex align-items-center">
             <div class="d-flex align-items-center">
-                <div class="avatar">
-                    <img src="{$avatarUrl}" alt="avatar">
+                <div class="avatar avatar-preview">
+                    <img src="{$avatarUrl}" alt="avatar" class="avatar-img">
+                    <img src="{$avatarBorderUrl}" alt="avatar border" class="avatar-border-overlay">
                 </div>
                 <div class="meta ml-3">
                     <h3 class="nickname mb-1 d-flex align-items-center">

--- a/src/private/templates/profile.latte
+++ b/src/private/templates/profile.latte
@@ -41,7 +41,9 @@
                             <span class="status-dot green"></span>
                             <small>
                                 Online since
-                                {ifset $profile["online_since_ms"]}
+                                {ifset $profile["online_since_text"]}
+                                    {$profile["online_since_text"]}
+                                {elseifset $profile["online_since_ms"]}
                                     {round(($profile["online_since_ms"] / 1000) / 60)} minutes
                                 {else}
                                     a moment

--- a/src/private/templates/profile.latte
+++ b/src/private/templates/profile.latte
@@ -52,7 +52,9 @@
                             </small>
                         {else}
                             <span class="status-dot gray"></span>
-                            <small>Offline</small>
+                            <small>
+                                Offline{ifset $lastSeenText} • last seen {$lastSeenText}{/ifset}
+                            </small>
                         {/if}
                     </div>
                 </div>

--- a/src/profile.php
+++ b/src/profile.php
@@ -301,9 +301,8 @@ if ((empty($profileData["nickname"]) || $profileData["nickname"] === null) && $d
 if ((empty($profileData["servergroups"]) || $profileData["servergroups"] === null) && $dbProfile && !empty($dbProfile["servergroups"])) {
     $profileData["servergroups"] = (string) $dbProfile["servergroups"];
 }
-// Preserve timestamps always; only preserve totalconnections when online
-$preserveNumericKeys = ["created_ts", "lastconnected_ts"];
-if ($isOnline) { $preserveNumericKeys[] = "totalconnections"; }
+// Preserve timestamps and total connections always (even when offline)
+$preserveNumericKeys = ["created_ts", "lastconnected_ts", "totalconnections"];
 foreach ($preserveNumericKeys as $k) {
     if (!isset($profileData[$k]) || $profileData[$k] === null) {
         if ($dbProfile && isset($dbProfile[$k]) && $dbProfile[$k] !== null) {
@@ -338,8 +337,6 @@ if (!$isOnline) {
     } catch (\Exception $e) {
         // ignore cache errors
     }
-    // Force totalconnections to be hidden offline
-    $profileData["totalconnections"] = null;
 }
 
 // Resolve current channel name if available
@@ -441,6 +438,14 @@ if (!$isOnline) {
     }
 
     $renderData["lastSeenText"] = $lastSeenText;
+}
+
+// Compute human-readable first connected and last online date strings for Overview
+if (isset($profileData["created_ts"]) && is_numeric($profileData["created_ts"])) {
+    $renderData["profile"]["first_connected_human"] = date('jS F, Y', (int) $profileData["created_ts"]);
+}
+if (isset($profileData["lastconnected_ts"]) && is_numeric($profileData["lastconnected_ts"])) {
+    $renderData["profile"]["last_online_human"] = date('jS F, Y, g:ia', (int) $profileData["lastconnected_ts"]);
 }
 
 TemplateUtils::i()->renderTemplate("profile", $renderData);

--- a/src/profile.php
+++ b/src/profile.php
@@ -40,12 +40,31 @@ try {
             `created_ts` INT(11) DEFAULT NULL,
             `lastconnected_ts` INT(11) DEFAULT NULL,
             `totalconnections` INT(11) DEFAULT NULL,
+            `bw_up_last_minute` BIGINT UNSIGNED DEFAULT NULL,
+            `bw_down_last_minute` BIGINT UNSIGNED DEFAULT NULL,
             `updated_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
             PRIMARY KEY (`id`),
             UNIQUE KEY `uniq_cldbid` (`cldbid`)
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;";
 
         $db->query($createSql);
+    } else {
+        // Ensure bandwidth columns exist for offline fallback display
+        try {
+            $colStmt = $db->query("SHOW COLUMNS FROM `{$rawTableName}` LIKE 'bw_up_last_minute'");
+            $hasUp = $colStmt && $colStmt->fetchColumn();
+        } catch (\Exception $e) { $hasUp = false; }
+        try {
+            $colStmt = $db->query("SHOW COLUMNS FROM `{$rawTableName}` LIKE 'bw_down_last_minute'");
+            $hasDown = $colStmt && $colStmt->fetchColumn();
+        } catch (\Exception $e) { $hasDown = false; }
+
+        if (!$hasUp) {
+            try { $db->query("ALTER TABLE `{$rawTableName}` ADD COLUMN `bw_up_last_minute` BIGINT UNSIGNED DEFAULT NULL AFTER `totalconnections`"); } catch (\Exception $e) { /* ignore */ }
+        }
+        if (!$hasDown) {
+            try { $db->query("ALTER TABLE `{$rawTableName}` ADD COLUMN `bw_down_last_minute` BIGINT UNSIGNED DEFAULT NULL AFTER `bw_up_last_minute`"); } catch (\Exception $e) { /* ignore */ }
+        }
     }
 } catch (\Exception $e) {
     TemplateUtils::i()->renderErrorTemplate("DB error", "Failed ensuring profiles table", $e->getMessage());
@@ -80,6 +99,8 @@ $profileData = [
     "created_ts" => null,
     "lastconnected_ts" => null,
     "totalconnections" => null,
+    "bw_up_last_minute" => null,
+    "bw_down_last_minute" => null,
 ];
 
 if ($tsInfo) {
@@ -281,6 +302,30 @@ foreach (["country", "version", "platform", "badges"] as $k) {
     if (!isset($profileData[$k]) || $profileData[$k] === null || $profileData[$k] === '') {
         if ($dbProfile && isset($dbProfile[$k]) && $dbProfile[$k] !== null && $dbProfile[$k] !== '') {
             $profileData[$k] = $dbProfile[$k];
+        }
+    }
+}
+
+// Bandwidth offline fallback: compute human-readable from last saved minute totals
+if (!$isOnline) {
+    if (!isset($profileData["bw_up_h"]) || $profileData["bw_up_h"] === null) {
+        if ($dbProfile && isset($dbProfile["bw_up_last_minute"]) && is_numeric($dbProfile["bw_up_last_minute"])) {
+            $upBps = ((float) $dbProfile["bw_up_last_minute"]) / 60.0;
+            $profileData["bw_up_h"] = ($upBps >= 1024*1024)
+                ? number_format($upBps / (1024*1024), 2) . " MB/s"
+                : (($upBps >= 1024)
+                    ? number_format($upBps / 1024, 2) . " KB/s"
+                    : number_format($upBps, 0) . " B/s");
+        }
+    }
+    if (!isset($profileData["bw_down_h"]) || $profileData["bw_down_h"] === null) {
+        if ($dbProfile && isset($dbProfile["bw_down_last_minute"]) && is_numeric($dbProfile["bw_down_last_minute"])) {
+            $downBps = ((float) $dbProfile["bw_down_last_minute"]) / 60.0;
+            $profileData["bw_down_h"] = ($downBps >= 1024*1024)
+                ? number_format($downBps / (1024*1024), 2) . " MB/s"
+                : (($downBps >= 1024)
+                    ? number_format($downBps / 1024, 2) . " KB/s"
+                    : number_format($downBps, 0) . " B/s");
         }
     }
 }

--- a/src/profile.php
+++ b/src/profile.php
@@ -111,6 +111,18 @@ if ($onlineClient) {
             $live = TeamSpeakUtils::i()->getTSNodeServer()->clientGetById($profileData["clid"])->getInfo(true);
             if (isset($live["connection_connected_time"])) {
                 $profileData["online_since_ms"] = (int) $live["connection_connected_time"]; // milliseconds
+                // Build human readable duration: days, hours, minutes, seconds
+                $totalSeconds = (int) floor(((int) $profileData["online_since_ms"]) / 1000);
+                $days = (int) floor($totalSeconds / 86400);
+                $hours = (int) floor(($totalSeconds % 86400) / 3600);
+                $minutes = (int) floor(($totalSeconds % 3600) / 60);
+                $seconds = (int) ($totalSeconds % 60);
+                $parts = [];
+                if ($days > 0) { $parts[] = $days . " day" . ($days !== 1 ? "s" : ""); }
+                if ($hours > 0) { $parts[] = $hours . " hour" . ($hours !== 1 ? "s" : ""); }
+                if ($minutes > 0) { $parts[] = $minutes . " minute" . ($minutes !== 1 ? "s" : ""); }
+                $parts[] = $seconds . " second" . ($seconds !== 1 ? "s" : "");
+                $profileData["online_since_text"] = implode(" ", $parts);
             }
             if (isset($live["client_totalconnections"])) {
                 $profileData["totalconnections"] = (int) $live["client_totalconnections"]; // live value preferred when online

--- a/src/profile.php
+++ b/src/profile.php
@@ -5,6 +5,7 @@ use Wruczek\TSWebsite\Utils\DatabaseUtils;
 use Wruczek\TSWebsite\Utils\TemplateUtils;
 use Wruczek\TSWebsite\Config;
 use Wruczek\TSWebsite\Utils\TeamSpeakUtils;
+use Wruczek\PhpFileCache\PhpFileCache;
 
 require_once __DIR__ . "/private/php/load.php";
 
@@ -40,31 +41,12 @@ try {
             `created_ts` INT(11) DEFAULT NULL,
             `lastconnected_ts` INT(11) DEFAULT NULL,
             `totalconnections` INT(11) DEFAULT NULL,
-            `bw_up_last_minute` BIGINT UNSIGNED DEFAULT NULL,
-            `bw_down_last_minute` BIGINT UNSIGNED DEFAULT NULL,
             `updated_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
             PRIMARY KEY (`id`),
             UNIQUE KEY `uniq_cldbid` (`cldbid`)
         ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;";
 
         $db->query($createSql);
-    } else {
-        // Ensure bandwidth columns exist for offline fallback display
-        try {
-            $colStmt = $db->query("SHOW COLUMNS FROM `{$rawTableName}` LIKE 'bw_up_last_minute'");
-            $hasUp = $colStmt && $colStmt->fetchColumn();
-        } catch (\Exception $e) { $hasUp = false; }
-        try {
-            $colStmt = $db->query("SHOW COLUMNS FROM `{$rawTableName}` LIKE 'bw_down_last_minute'");
-            $hasDown = $colStmt && $colStmt->fetchColumn();
-        } catch (\Exception $e) { $hasDown = false; }
-
-        if (!$hasUp) {
-            try { $db->query("ALTER TABLE `{$rawTableName}` ADD COLUMN `bw_up_last_minute` BIGINT UNSIGNED DEFAULT NULL AFTER `totalconnections`"); } catch (\Exception $e) { /* ignore */ }
-        }
-        if (!$hasDown) {
-            try { $db->query("ALTER TABLE `{$rawTableName}` ADD COLUMN `bw_down_last_minute` BIGINT UNSIGNED DEFAULT NULL AFTER `bw_up_last_minute`"); } catch (\Exception $e) { /* ignore */ }
-        }
     }
 } catch (\Exception $e) {
     TemplateUtils::i()->renderErrorTemplate("DB error", "Failed ensuring profiles table", $e->getMessage());
@@ -99,8 +81,6 @@ $profileData = [
     "created_ts" => null,
     "lastconnected_ts" => null,
     "totalconnections" => null,
-    "bw_up_last_minute" => null,
-    "bw_down_last_minute" => null,
 ];
 
 if ($tsInfo) {
@@ -137,8 +117,8 @@ if ($onlineClient) {
             }
             // Bandwidth last minute totals (bytes) -> compute per-second and human readable
             if (isset($live["connection_bandwidth_sent_last_minute_total"])) {
-                $profileData["bw_up_last_minute"] = (int) $live["connection_bandwidth_sent_last_minute_total"];
-                $upBps = $profileData["bw_up_last_minute"] / 60.0;
+                $lastUpTotal = (int) $live["connection_bandwidth_sent_last_minute_total"];
+                $upBps = $lastUpTotal / 60.0;
                 $profileData["bw_up_h"] = ($upBps >= 1024*1024)
                     ? number_format($upBps / (1024*1024), 2) . " MB/s"
                     : (($upBps >= 1024)
@@ -146,8 +126,8 @@ if ($onlineClient) {
                         : number_format($upBps, 0) . " B/s");
             }
             if (isset($live["connection_bandwidth_received_last_minute_total"])) {
-                $profileData["bw_down_last_minute"] = (int) $live["connection_bandwidth_received_last_minute_total"];
-                $downBps = $profileData["bw_down_last_minute"] / 60.0;
+                $lastDownTotal = (int) $live["connection_bandwidth_received_last_minute_total"];
+                $downBps = $lastDownTotal / 60.0;
                 $profileData["bw_down_h"] = ($downBps >= 1024*1024)
                     ? number_format($downBps / (1024*1024), 2) . " MB/s"
                     : (($downBps >= 1024)
@@ -157,6 +137,26 @@ if ($onlineClient) {
         }
     } catch (\Exception $e) {
         // ignore
+    }
+}
+
+// Store last seen display data in cache when online for offline reuse (no DB changes)
+if ($isOnline) {
+    try {
+        $lastSeenCache = new PhpFileCache(__CACHE_DIR, "profile_last_seen");
+        $lastSeenData = [
+            "country" => $profileData["country"] ?? null,
+            "version" => $profileData["version"] ?? null,
+            "platform" => $profileData["platform"] ?? null,
+            "totalconnections" => $profileData["totalconnections"] ?? null,
+            "bw_up_h" => $profileData["bw_up_h"] ?? null,
+            "bw_down_h" => $profileData["bw_down_h"] ?? null,
+            "nickname" => $profileData["nickname"] ?? null,
+            "ts" => time(),
+        ];
+        $lastSeenCache->store("u_" . (int) $cldbid, $lastSeenData, 31536000); // 365 days
+    } catch (\Exception $e) {
+        // ignore cache errors
     }
 }
 
@@ -306,27 +306,22 @@ foreach (["country", "version", "platform", "badges"] as $k) {
     }
 }
 
-// Bandwidth offline fallback: compute human-readable from last saved minute totals
+// Offline fallback: use last seen values from cache so UI shows the last online data
 if (!$isOnline) {
-    if (!isset($profileData["bw_up_h"]) || $profileData["bw_up_h"] === null) {
-        if ($dbProfile && isset($dbProfile["bw_up_last_minute"]) && is_numeric($dbProfile["bw_up_last_minute"])) {
-            $upBps = ((float) $dbProfile["bw_up_last_minute"]) / 60.0;
-            $profileData["bw_up_h"] = ($upBps >= 1024*1024)
-                ? number_format($upBps / (1024*1024), 2) . " MB/s"
-                : (($upBps >= 1024)
-                    ? number_format($upBps / 1024, 2) . " KB/s"
-                    : number_format($upBps, 0) . " B/s");
+    try {
+        $lastSeenCache = new PhpFileCache(__CACHE_DIR, "profile_last_seen");
+        $last = $lastSeenCache->retrieve("u_" . (int) $cldbid);
+        if (is_array($last)) {
+            foreach (["country", "version", "platform", "totalconnections", "bw_up_h", "bw_down_h", "nickname"] as $k) {
+                if (!isset($profileData[$k]) || $profileData[$k] === null || $profileData[$k] === '') {
+                    if (isset($last[$k]) && $last[$k] !== null && $last[$k] !== '') {
+                        $profileData[$k] = $last[$k];
+                    }
+                }
+            }
         }
-    }
-    if (!isset($profileData["bw_down_h"]) || $profileData["bw_down_h"] === null) {
-        if ($dbProfile && isset($dbProfile["bw_down_last_minute"]) && is_numeric($dbProfile["bw_down_last_minute"])) {
-            $downBps = ((float) $dbProfile["bw_down_last_minute"]) / 60.0;
-            $profileData["bw_down_h"] = ($downBps >= 1024*1024)
-                ? number_format($downBps / (1024*1024), 2) . " MB/s"
-                : (($downBps >= 1024)
-                    ? number_format($downBps / 1024, 2) . " KB/s"
-                    : number_format($downBps, 0) . " B/s");
-        }
+    } catch (\Exception $e) {
+        // ignore cache errors
     }
 }
 

--- a/src/profile.php
+++ b/src/profile.php
@@ -1,6 +1,7 @@
 <?php
 
 use Wruczek\TSWebsite\CacheManager;
+use Wruczek\TSWebsite\Utils\AvatarBorderUtils;
 use Wruczek\TSWebsite\Utils\DatabaseUtils;
 use Wruczek\TSWebsite\Utils\TemplateUtils;
 use Wruczek\TSWebsite\Config;
@@ -302,6 +303,8 @@ if (!empty($groupsDetailed)) {
 
 $avatarUrl = ($dbProfile && !empty($dbProfile["avatar_url"])) ? $dbProfile["avatar_url"] : "img/icons/defaulticon-128.png";
 $bannerUrl = ($dbProfile && !empty($dbProfile["banner_url"])) ? $dbProfile["banner_url"] : null;
+$avatarBorderKey = $dbProfile && isset($dbProfile["avatar_border"]) ? AvatarBorderUtils::normalize($dbProfile["avatar_border"]) : AvatarBorderUtils::getDefaultKey();
+$avatarBorderUrl = AvatarBorderUtils::getUrl($avatarBorderKey);
 // Prefer user-saved description if present
 if ($dbProfile && !empty($dbProfile["description"])) {
     $profileData["description"] = (string) $dbProfile["description"];
@@ -407,6 +410,8 @@ $renderData = [
     "isOnline" => $isOnline,
     "profile" => $profileData,
     "avatarUrl" => $avatarUrl,
+    "avatarBorderUrl" => $avatarBorderUrl,
+    "avatarBorderKey" => $avatarBorderKey,
     "bannerUrl" => $bannerUrl,
     "groups" => $groupsDetailed,
     "socials" => $socialItems,

--- a/src/profile.php
+++ b/src/profile.php
@@ -390,5 +390,46 @@ $renderData = [
     "rankLevel" => $rankLevel,
 ];
 
+// Compute last seen text for offline users
+if (!$isOnline) {
+    $lastSeenTs = null;
+    if (isset($profileData["lastconnected_ts"]) && is_numeric($profileData["lastconnected_ts"])) {
+        $lastSeenTs = (int) $profileData["lastconnected_ts"]; // unix seconds
+    }
+    if ($lastSeenTs === null) {
+        try {
+            $lastSeenCache = new \Wruczek\PhpFileCache\PhpFileCache(__CACHE_DIR, "profile_last_seen");
+            $cached = $lastSeenCache->retrieve("u_" . (int) $cldbid);
+            if (is_array($cached) && isset($cached["ts"]) && is_numeric($cached["ts"])) {
+                $lastSeenTs = (int) $cached["ts"];
+            }
+        } catch (\Exception $e) {
+            // ignore
+        }
+    }
+
+    $lastSeenText = null;
+    if ($lastSeenTs !== null && $lastSeenTs > 0) {
+        $now = time();
+        $diff = max(0, $now - $lastSeenTs);
+        if ($diff < 60) {
+            $lastSeenText = (int) $diff . " seconds ago";
+        } else if ($diff < 3600) { // < 60 minutes
+            $mins = (int) floor($diff / 60);
+            $lastSeenText = $mins . " minute" . ($mins !== 1 ? "s" : "") . " ago";
+        } else if ($diff < 86400) { // < 24 hours
+            $hrs = (int) floor($diff / 3600);
+            $lastSeenText = $hrs . " hour" . ($hrs !== 1 ? "s" : "") . " ago";
+        } else if ($diff < 2592000) { // < 30 days
+            $days = (int) floor($diff / 86400);
+            $lastSeenText = $days . " day" . ($days !== 1 ? "s" : "") . " ago";
+        } else {
+            $lastSeenText = date('d/m/Y', $lastSeenTs);
+        }
+    }
+
+    $renderData["lastSeenText"] = $lastSeenText;
+}
+
 TemplateUtils::i()->renderTemplate("profile", $renderData);
 

--- a/src/profile.php
+++ b/src/profile.php
@@ -289,7 +289,10 @@ if ((empty($profileData["nickname"]) || $profileData["nickname"] === null) && $d
 if ((empty($profileData["servergroups"]) || $profileData["servergroups"] === null) && $dbProfile && !empty($dbProfile["servergroups"])) {
     $profileData["servergroups"] = (string) $dbProfile["servergroups"];
 }
-foreach (["created_ts", "lastconnected_ts", "totalconnections"] as $k) {
+// Preserve timestamps always; only preserve totalconnections when online
+$preserveNumericKeys = ["created_ts", "lastconnected_ts"];
+if ($isOnline) { $preserveNumericKeys[] = "totalconnections"; }
+foreach ($preserveNumericKeys as $k) {
     if (!isset($profileData[$k]) || $profileData[$k] === null) {
         if ($dbProfile && isset($dbProfile[$k]) && $dbProfile[$k] !== null) {
             $profileData[$k] = is_numeric($dbProfile[$k]) ? (int) $dbProfile[$k] : $dbProfile[$k];
@@ -312,7 +315,7 @@ if (!$isOnline) {
         $lastSeenCache = new PhpFileCache(__CACHE_DIR, "profile_last_seen");
         $last = $lastSeenCache->retrieve("u_" . (int) $cldbid);
         if (is_array($last)) {
-            foreach (["country", "version", "platform", "totalconnections", "bw_up_h", "bw_down_h", "nickname"] as $k) {
+            foreach (["country", "version", "platform", "bw_up_h", "bw_down_h", "nickname"] as $k) {
                 if (!isset($profileData[$k]) || $profileData[$k] === null || $profileData[$k] === '') {
                     if (isset($last[$k]) && $last[$k] !== null && $last[$k] !== '') {
                         $profileData[$k] = $last[$k];
@@ -323,6 +326,8 @@ if (!$isOnline) {
     } catch (\Exception $e) {
         // ignore cache errors
     }
+    // Force totalconnections to be hidden offline
+    $profileData["totalconnections"] = null;
 }
 
 // Resolve current channel name if available

--- a/src/profile.php
+++ b/src/profile.php
@@ -61,7 +61,20 @@ $tsInfo = null;
 try {
     if (TeamSpeakUtils::i()->checkTSConnection()) {
         // TS3 server query command is "clientdbinfo" -> method name clientDbInfo
-        $tsInfo = TeamSpeakUtils::i()->getTSNodeServer()->clientDbInfo($cldbid);
+        try {
+            $tsInfo = TeamSpeakUtils::i()->getTSNodeServer()->clientDbInfo($cldbid);
+        } catch (\Exception $e1) {
+            // Fallback to raw request in case wrapper call fails
+            try {
+                $reply = TeamSpeakUtils::i()->getTSNodeServer()->request("clientdbinfo cldbid=" . (int) $cldbid);
+                $list = $reply && method_exists($reply, 'toList') ? $reply->toList() : null;
+                if (is_array($list) && isset($list[0])) {
+                    $tsInfo = $list[0];
+                }
+            } catch (\Exception $e2) {
+                // ignore
+            }
+        }
     }
 } catch (\Exception $e) {
     // Non-fatal: proceed with what we have
@@ -332,6 +345,10 @@ if (!$isOnline) {
                         $profileData[$k] = $last[$k];
                     }
                 }
+            }
+            // Use cached timestamp as lastconnected_ts fallback if missing
+            if ((!isset($profileData["lastconnected_ts"]) || $profileData["lastconnected_ts"] === null) && isset($last['ts']) && is_numeric($last['ts'])) {
+                $profileData["lastconnected_ts"] = (int) $last['ts'];
             }
         }
     } catch (\Exception $e) {


### PR DESCRIPTION
This pull request contains changes generated by Cursor background composer.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add bandwidth tracking to profiles with DB columns, live capture, and offline fallback display.
> 
> - **Database**:
>   - Add `bw_up_last_minute` and `bw_down_last_minute` columns to `profiles`; ensure columns exist via conditional `ALTER TABLE` when table already present.
> - **Profile Data & Logic**:
>   - Capture live `connection_bandwidth_*_last_minute_total`, compute per-second human-readable `bw_up_h`/`bw_down_h`, and include values in `profileData`.
>   - Offline fallback: compute `bw_up_h`/`bw_down_h` from stored last-minute totals.
>   - Extend normalized `profileData` to include new bandwidth fields.
>   - Preserve additional overview fields (`country`, `version`, `platform`, `badges`) from DB when missing/offline.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9f82b04e59a988b83c5e0120fd3474b072105256. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->