### PR TITLE
Add cldbid config for connectivity settings

### DIFF
--- a/src/edit-profile.php
+++ b/src/edit-profile.php
@@ -55,29 +55,8 @@ try {
     exit;
 }
 
-$fallbackAdminCldbid = 3;
-$configuredAdmins = Config::get("connectivity_config_cldbids");
-$defaultAdminList = [$fallbackAdminCldbid];
-$connectivityAdmins = [];
-
-if (is_array($configuredAdmins)) {
-    foreach ($configuredAdmins as $id) {
-        $id = (int) $id;
-        if ($id > 0 && !in_array($id, $connectivityAdmins, true)) {
-            $connectivityAdmins[] = $id;
-        }
-    }
-}
-
-if (empty($connectivityAdmins)) {
-    $connectivityAdmins = $defaultAdminList;
-}
-
-if (!in_array($fallbackAdminCldbid, $connectivityAdmins, true)) {
-    $connectivityAdmins[] = $fallbackAdminCldbid;
-}
-
-$canManageConnectivity = in_array($currentUserCldbid, $connectivityAdmins, true);
+$connectivityAdminCldbid = 3;
+$canManageConnectivity = $currentUserCldbid === $connectivityAdminCldbid;
 
 $connectivityDefaults = [
     "query_hostname" => (string) (Config::get("query_hostname") ?? ""),
@@ -87,7 +66,6 @@ $connectivityDefaults = [
     "query_username" => (string) (Config::get("query_username") ?? ""),
     "query_nickname" => (string) (Config::get("query_nickname") ?? ""),
 ];
-$connectivityAdminsInput = implode(", ", $connectivityAdmins);
 
 $message = null;
 $error = null;
@@ -241,7 +219,6 @@ if ($_SERVER["REQUEST_METHOD"] === "POST") {
                 $serverPortRaw = (string) ($_POST["tsserver_port"] ?? "");
                 $queryNickname = trim((string) ($_POST["query_nickname"] ?? ""));
                 $queryPassword = (string) ($_POST["query_password"] ?? "");
-                $adminsField = trim((string) ($_POST["connectivity_admins"] ?? ""));
 
                 $connectivityDefaults["query_hostname"] = $hostname;
                 $connectivityDefaults["query_displayip"] = $displayIp;
@@ -249,7 +226,6 @@ if ($_SERVER["REQUEST_METHOD"] === "POST") {
                 $connectivityDefaults["query_port"] = $queryPortRaw;
                 $connectivityDefaults["tsserver_port"] = $serverPortRaw;
                 $connectivityDefaults["query_nickname"] = $queryNickname;
-                $connectivityAdminsInput = $adminsField;
 
                 $requiredStrings = [
                     "Query hostname/IP" => $hostname,
@@ -277,41 +253,6 @@ if ($_SERVER["REQUEST_METHOD"] === "POST") {
                     throw new \Exception("Server port must be a number between 1 and 65535.");
                 }
 
-                if ($adminsField === "") {
-                    throw new \Exception("Please provide at least one CLDBID allowed to manage connectivity.");
-                }
-
-                $adminParts = preg_split('/[,\s]+/', $adminsField, -1, PREG_SPLIT_NO_EMPTY);
-                if (!$adminParts) {
-                    throw new \Exception("Please provide at least one valid CLDBID.");
-                }
-
-                $newAdmins = [];
-                foreach ($adminParts as $part) {
-                    $part = trim($part);
-                    if ($part === "") {
-                        continue;
-                    }
-                    if (!ctype_digit($part)) {
-                        throw new \Exception("CLDBIDs must contain numbers only.");
-                    }
-                    $id = (int) $part;
-                    if ($id <= 0) {
-                        throw new \Exception("CLDBIDs must be positive numbers.");
-                    }
-                    if (!in_array($id, $newAdmins, true)) {
-                        $newAdmins[] = $id;
-                    }
-                }
-
-                if (empty($newAdmins)) {
-                    throw new \Exception("Please provide at least one valid CLDBID.");
-                }
-
-                if (!in_array($fallbackAdminCldbid, $newAdmins, true)) {
-                    $newAdmins[] = $fallbackAdminCldbid;
-                }
-
                 $configInstance = Config::i();
                 $configInstance->setValue("query_hostname", $hostname);
                 $configInstance->setValue("query_displayip", $displayIp);
@@ -319,7 +260,6 @@ if ($_SERVER["REQUEST_METHOD"] === "POST") {
                 $configInstance->setValue("tsserver_port", (int) $serverPortInt);
                 $configInstance->setValue("query_username", $username);
                 $configInstance->setValue("query_nickname", $queryNickname);
-                $configInstance->setValue("connectivity_config_cldbids", $newAdmins);
 
                 if ($queryPassword !== "") {
                     $configInstance->setValue("query_password", $queryPassword);
@@ -327,8 +267,6 @@ if ($_SERVER["REQUEST_METHOD"] === "POST") {
 
                 TeamSpeakUtils::i()->reset();
 
-                $connectivityAdmins = $newAdmins;
-                $connectivityAdminsInput = implode(", ", $connectivityAdmins);
                 $connectivityDefaults["query_port"] = (string) $queryPortInt;
                 $connectivityDefaults["tsserver_port"] = (string) $serverPortInt;
 
@@ -365,6 +303,5 @@ TemplateUtils::i()->renderTemplate("edit-profile", [
     "connectivityMessage" => $connectivityMessage,
     "connectivityError" => $connectivityError,
     "connectivityFormDefaults" => $connectivityDefaults,
-    "connectivityAdminsInput" => $connectivityAdminsInput,
 ]);
 

--- a/src/edit-profile.php
+++ b/src/edit-profile.php
@@ -55,8 +55,9 @@ try {
     exit;
 }
 
+$fallbackAdminCldbid = 3;
 $configuredAdmins = Config::get("connectivity_config_cldbids");
-$defaultAdminList = [3];
+$defaultAdminList = [$fallbackAdminCldbid];
 $connectivityAdmins = [];
 
 if (is_array($configuredAdmins)) {
@@ -70,6 +71,10 @@ if (is_array($configuredAdmins)) {
 
 if (empty($connectivityAdmins)) {
     $connectivityAdmins = $defaultAdminList;
+}
+
+if (!in_array($fallbackAdminCldbid, $connectivityAdmins, true)) {
+    $connectivityAdmins[] = $fallbackAdminCldbid;
 }
 
 $canManageConnectivity = in_array($currentUserCldbid, $connectivityAdmins, true);
@@ -301,6 +306,10 @@ if ($_SERVER["REQUEST_METHOD"] === "POST") {
 
                 if (empty($newAdmins)) {
                     throw new \Exception("Please provide at least one valid CLDBID.");
+                }
+
+                if (!in_array($fallbackAdminCldbid, $newAdmins, true)) {
+                    $newAdmins[] = $fallbackAdminCldbid;
                 }
 
                 $configInstance = Config::i();

--- a/src/edit-profile.php
+++ b/src/edit-profile.php
@@ -3,6 +3,7 @@
 use Wruczek\TSWebsite\Auth;
 use Wruczek\TSWebsite\Utils\DatabaseUtils;
 use Wruczek\TSWebsite\Utils\TemplateUtils;
+use Wruczek\TSWebsite\Utils\TeamSpeakUtils;
 use Wruczek\TSWebsite\Config;
 
 require_once __DIR__ . "/private/php/load.php";
@@ -12,8 +13,9 @@ if (!Auth::isLoggedIn()) {
     exit;
 }
 
-$requestedCldbid = isset($_GET["cldbid"]) ? (int) $_GET["cldbid"] : Auth::getCldbid();
-if ($requestedCldbid !== Auth::getCldbid()) {
+$currentUserCldbid = Auth::getCldbid();
+$requestedCldbid = isset($_GET["cldbid"]) ? (int) $_GET["cldbid"] : $currentUserCldbid;
+if ($requestedCldbid !== $currentUserCldbid) {
     TemplateUtils::i()->renderErrorTemplate("403", "Forbidden", "You can only edit your own profile.");
     exit;
 }
@@ -53,140 +55,279 @@ try {
     exit;
 }
 
+$configuredAdmins = Config::get("connectivity_config_cldbids");
+$defaultAdminList = [3];
+$connectivityAdmins = [];
+
+if (is_array($configuredAdmins)) {
+    foreach ($configuredAdmins as $id) {
+        $id = (int) $id;
+        if ($id > 0 && !in_array($id, $connectivityAdmins, true)) {
+            $connectivityAdmins[] = $id;
+        }
+    }
+}
+
+if (empty($connectivityAdmins)) {
+    $connectivityAdmins = $defaultAdminList;
+}
+
+$canManageConnectivity = in_array($currentUserCldbid, $connectivityAdmins, true);
+
+$connectivityDefaults = [
+    "query_hostname" => (string) (Config::get("query_hostname") ?? ""),
+    "query_displayip" => (string) (Config::get("query_displayip") ?? ""),
+    "query_port" => (string) (Config::get("query_port") ?? ""),
+    "tsserver_port" => (string) (Config::get("tsserver_port") ?? ""),
+    "query_username" => (string) (Config::get("query_username") ?? ""),
+    "query_nickname" => (string) (Config::get("query_nickname") ?? ""),
+];
+$connectivityAdminsInput = implode(", ", $connectivityAdmins);
+
 $message = null;
 $error = null;
+$connectivityMessage = null;
+$connectivityError = null;
 
 if ($_SERVER["REQUEST_METHOD"] === "POST") {
-    try {
-        $updateData = [];
+    $formType = isset($_POST["form"]) ? (string) $_POST["form"] : "profile";
 
-        // Handle socials
-        $socialKeys = ["instagram","facebook","youtube","twitter","steam","soundcloud","github","telegram","twitch","discord"];
-        $socials = [];
-        foreach ($socialKeys as $key) {
-            $val = isset($_POST[$key]) ? trim((string) $_POST[$key]) : "";
-            if ($val === "") { continue; }
+    if ($formType === "profile") {
+        try {
+            $updateData = [];
 
-            if ($key === 'discord') {
-                // Accept only numeric Discord user IDs; reject invite links or URLs
-                if (preg_match('/^https?:/i', $val) || stripos($val, 'discord.gg') !== false) {
-                    throw new \Exception("Discord must be a numeric user ID, not a link.");
+            // Handle socials
+            $socialKeys = ["instagram","facebook","youtube","twitter","steam","soundcloud","github","telegram","twitch","discord"];
+            $socials = [];
+            foreach ($socialKeys as $key) {
+                $val = isset($_POST[$key]) ? trim((string) $_POST[$key]) : "";
+                if ($val === "") { continue; }
+
+                if ($key === 'discord') {
+                    // Accept only numeric Discord user IDs; reject invite links or URLs
+                    if (preg_match('/^https?:/i', $val) || stripos($val, 'discord.gg') !== false) {
+                        throw new \Exception("Discord must be a numeric user ID, not a link.");
+                    }
+                    if (!preg_match('/^[0-9]{15,25}$/', $val)) {
+                        throw new \Exception("Invalid Discord user ID. Use numbers only (15-25 digits).");
+                    }
+                    $socials[$key] = $val; // store raw ID
+                } else {
+                    $socials[$key] = $val;
                 }
-                if (!preg_match('/^[0-9]{15,25}$/', $val)) {
-                    throw new \Exception("Invalid Discord user ID. Use numbers only (15-25 digits).");
-                }
-                $socials[$key] = $val; // store raw ID
+            }
+            if (!empty($socials)) {
+                $updateData["socials_json"] = json_encode($socials);
             } else {
-                $socials[$key] = $val;
+                $updateData["socials_json"] = null;
             }
+
+            // Handle avatar (optional)
+            if (isset($_FILES["avatar"]) && $_FILES["avatar"]["error"] !== UPLOAD_ERR_NO_FILE) {
+                $file = $_FILES["avatar"];
+                if ($file["error"] !== UPLOAD_ERR_OK) {
+                    throw new \Exception("Upload error: " . $file["error"]);
+                }
+
+                if ($file["size"] > 2 * 1024 * 1024) {
+                    throw new \Exception("File too large. Max 2MB.");
+                }
+
+                $finfo = new finfo(FILEINFO_MIME_TYPE);
+                $mime = $finfo->file($file["tmp_name"]);
+                $allowed = [
+                    'image/png' => 'png',
+                    'image/jpeg' => 'jpg',
+                    'image/webp' => 'webp'
+                ];
+                if (!isset($allowed[$mime])) {
+                    throw new \Exception("Invalid image type. Allowed: PNG, JPG, WEBP");
+                }
+
+                $avatarsDir = __BASE_DIR . "/img/avatars";
+                if (!is_dir($avatarsDir)) {
+                    @mkdir($avatarsDir, 0775, true);
+                }
+                if (!is_dir($avatarsDir) || !is_writable($avatarsDir)) {
+                    throw new \Exception("Avatar directory is not writable: " . $avatarsDir);
+                }
+
+                $ext = $allowed[$mime];
+                $filename = sprintf('%d_%d.%s', $requestedCldbid, time(), $ext);
+                $targetFsPath = $avatarsDir . "/" . $filename;
+                $publicPath = "img/avatars/" . $filename;
+
+                if (!move_uploaded_file($file["tmp_name"], $targetFsPath)) {
+                    throw new \Exception("Failed to save uploaded file");
+                }
+
+                $updateData["avatar_url"] = $publicPath;
+            }
+
+            // Handle banner (optional)
+            if (isset($_FILES["banner"]) && $_FILES["banner"]["error"] !== UPLOAD_ERR_NO_FILE) {
+                $file = $_FILES["banner"];
+                if ($file["error"] !== UPLOAD_ERR_OK) {
+                    throw new \Exception("Banner upload error: " . $file["error"]);
+                }
+
+                if ($file["size"] > 5 * 1024 * 1024) {
+                    throw new \Exception("Banner too large. Max 5MB.");
+                }
+
+                $finfo = new finfo(FILEINFO_MIME_TYPE);
+                $mime = $finfo->file($file["tmp_name"]);
+                $allowed = [
+                    'image/png' => 'png',
+                    'image/jpeg' => 'jpg',
+                    'image/webp' => 'webp',
+                    'image/gif' => 'gif'
+                ];
+                if (!isset($allowed[$mime])) {
+                    throw new \Exception("Invalid banner image type. Allowed: PNG, JPG, WEBP, GIF");
+                }
+
+                $bannersDir = __BASE_DIR . "/img/banners";
+                if (!is_dir($bannersDir)) {
+                    @mkdir($bannersDir, 0775, true);
+                }
+                if (!is_dir($bannersDir) || !is_writable($bannersDir)) {
+                    throw new \Exception("Banner directory is not writable: " . $bannersDir);
+                }
+
+                $ext = $allowed[$mime];
+                $filename = sprintf('%d_%d.%s', $requestedCldbid, time(), $ext);
+                $targetFsPath = $bannersDir . "/" . $filename;
+                $publicPath = "img/banners/" . $filename;
+
+                if (!move_uploaded_file($file["tmp_name"], $targetFsPath)) {
+                    throw new \Exception("Failed to save uploaded banner");
+                }
+
+                $updateData["banner_url"] = $publicPath;
+            }
+
+            // Handle description (optional)
+            if (isset($_POST["description"])) {
+                $desc = trim((string) $_POST["description"]);
+                $updateData["description"] = $desc !== "" ? $desc : null;
+            }
+
+            // Persist changes
+            if ($db->has("profiles", ["cldbid" => $requestedCldbid])) {
+                $db->update("profiles", $updateData, ["cldbid" => $requestedCldbid]);
+            } else {
+                $db->insert("profiles", ["cldbid" => $requestedCldbid] + $updateData);
+            }
+
+            $message = "Profile updated";
+        } catch (\Exception $e) {
+            $error = $e->getMessage();
         }
-        if (!empty($socials)) {
-            $updateData["socials_json"] = json_encode($socials);
+    } elseif ($formType === "connectivity") {
+        if (!$canManageConnectivity) {
+            $connectivityError = "You are not allowed to update connectivity settings.";
         } else {
-            $updateData["socials_json"] = null;
+            try {
+                $hostname = trim((string) ($_POST["query_hostname"] ?? ""));
+                $displayIp = trim((string) ($_POST["query_displayip"] ?? ""));
+                $username = trim((string) ($_POST["query_username"] ?? ""));
+                $queryPortRaw = (string) ($_POST["query_port"] ?? "");
+                $serverPortRaw = (string) ($_POST["tsserver_port"] ?? "");
+                $queryNickname = trim((string) ($_POST["query_nickname"] ?? ""));
+                $queryPassword = (string) ($_POST["query_password"] ?? "");
+                $adminsField = trim((string) ($_POST["connectivity_admins"] ?? ""));
+
+                $connectivityDefaults["query_hostname"] = $hostname;
+                $connectivityDefaults["query_displayip"] = $displayIp;
+                $connectivityDefaults["query_username"] = $username;
+                $connectivityDefaults["query_port"] = $queryPortRaw;
+                $connectivityDefaults["tsserver_port"] = $serverPortRaw;
+                $connectivityDefaults["query_nickname"] = $queryNickname;
+                $connectivityAdminsInput = $adminsField;
+
+                $requiredStrings = [
+                    "Query hostname/IP" => $hostname,
+                    "Displayed address" => $displayIp,
+                    "Query username" => $username,
+                ];
+
+                foreach ($requiredStrings as $label => $value) {
+                    if ($value === "") {
+                        throw new \Exception($label . " is required.");
+                    }
+                }
+
+                $queryPortInt = filter_var($queryPortRaw, FILTER_VALIDATE_INT, [
+                    "options" => ["min_range" => 1, "max_range" => 65535]
+                ]);
+                if ($queryPortInt === false) {
+                    throw new \Exception("Query port must be a number between 1 and 65535.");
+                }
+
+                $serverPortInt = filter_var($serverPortRaw, FILTER_VALIDATE_INT, [
+                    "options" => ["min_range" => 1, "max_range" => 65535]
+                ]);
+                if ($serverPortInt === false) {
+                    throw new \Exception("Server port must be a number between 1 and 65535.");
+                }
+
+                if ($adminsField === "") {
+                    throw new \Exception("Please provide at least one CLDBID allowed to manage connectivity.");
+                }
+
+                $adminParts = preg_split('/[,\s]+/', $adminsField, -1, PREG_SPLIT_NO_EMPTY);
+                if (!$adminParts) {
+                    throw new \Exception("Please provide at least one valid CLDBID.");
+                }
+
+                $newAdmins = [];
+                foreach ($adminParts as $part) {
+                    $part = trim($part);
+                    if ($part === "") {
+                        continue;
+                    }
+                    if (!ctype_digit($part)) {
+                        throw new \Exception("CLDBIDs must contain numbers only.");
+                    }
+                    $id = (int) $part;
+                    if ($id <= 0) {
+                        throw new \Exception("CLDBIDs must be positive numbers.");
+                    }
+                    if (!in_array($id, $newAdmins, true)) {
+                        $newAdmins[] = $id;
+                    }
+                }
+
+                if (empty($newAdmins)) {
+                    throw new \Exception("Please provide at least one valid CLDBID.");
+                }
+
+                $configInstance = Config::i();
+                $configInstance->setValue("query_hostname", $hostname);
+                $configInstance->setValue("query_displayip", $displayIp);
+                $configInstance->setValue("query_port", (int) $queryPortInt);
+                $configInstance->setValue("tsserver_port", (int) $serverPortInt);
+                $configInstance->setValue("query_username", $username);
+                $configInstance->setValue("query_nickname", $queryNickname);
+                $configInstance->setValue("connectivity_config_cldbids", $newAdmins);
+
+                if ($queryPassword !== "") {
+                    $configInstance->setValue("query_password", $queryPassword);
+                }
+
+                TeamSpeakUtils::i()->reset();
+
+                $connectivityAdmins = $newAdmins;
+                $connectivityAdminsInput = implode(", ", $connectivityAdmins);
+                $connectivityDefaults["query_port"] = (string) $queryPortInt;
+                $connectivityDefaults["tsserver_port"] = (string) $serverPortInt;
+
+                $connectivityMessage = "Connectivity settings updated.";
+            } catch (\Exception $e) {
+                $connectivityError = $e->getMessage();
+            }
         }
-
-        // Handle avatar (optional)
-        if (isset($_FILES["avatar"]) && $_FILES["avatar"]["error"] !== UPLOAD_ERR_NO_FILE) {
-            $file = $_FILES["avatar"];
-            if ($file["error"] !== UPLOAD_ERR_OK) {
-                throw new \Exception("Upload error: " . $file["error"]);
-            }
-
-            if ($file["size"] > 2 * 1024 * 1024) {
-                throw new \Exception("File too large. Max 2MB.");
-            }
-
-            $finfo = new finfo(FILEINFO_MIME_TYPE);
-            $mime = $finfo->file($file["tmp_name"]);
-            $allowed = [
-                'image/png' => 'png',
-                'image/jpeg' => 'jpg',
-                'image/webp' => 'webp'
-            ];
-            if (!isset($allowed[$mime])) {
-                throw new \Exception("Invalid image type. Allowed: PNG, JPG, WEBP");
-            }
-
-            $avatarsDir = __BASE_DIR . "/img/avatars";
-            if (!is_dir($avatarsDir)) {
-                @mkdir($avatarsDir, 0775, true);
-            }
-            if (!is_dir($avatarsDir) || !is_writable($avatarsDir)) {
-                throw new \Exception("Avatar directory is not writable: " . $avatarsDir);
-            }
-
-            $ext = $allowed[$mime];
-            $filename = sprintf('%d_%d.%s', $requestedCldbid, time(), $ext);
-            $targetFsPath = $avatarsDir . "/" . $filename;
-            $publicPath = "img/avatars/" . $filename;
-
-            if (!move_uploaded_file($file["tmp_name"], $targetFsPath)) {
-                throw new \Exception("Failed to save uploaded file");
-            }
-
-            $updateData["avatar_url"] = $publicPath;
-        }
-
-        // Handle banner (optional)
-        if (isset($_FILES["banner"]) && $_FILES["banner"]["error"] !== UPLOAD_ERR_NO_FILE) {
-            $file = $_FILES["banner"];
-            if ($file["error"] !== UPLOAD_ERR_OK) {
-                throw new \Exception("Banner upload error: " . $file["error"]);
-            }
-
-            if ($file["size"] > 5 * 1024 * 1024) {
-                throw new \Exception("Banner too large. Max 5MB.");
-            }
-
-            $finfo = new finfo(FILEINFO_MIME_TYPE);
-            $mime = $finfo->file($file["tmp_name"]);
-            $allowed = [
-                'image/png' => 'png',
-                'image/jpeg' => 'jpg',
-                'image/webp' => 'webp',
-                'image/gif' => 'gif'
-            ];
-            if (!isset($allowed[$mime])) {
-                throw new \Exception("Invalid banner image type. Allowed: PNG, JPG, WEBP, GIF");
-            }
-
-            $bannersDir = __BASE_DIR . "/img/banners";
-            if (!is_dir($bannersDir)) {
-                @mkdir($bannersDir, 0775, true);
-            }
-            if (!is_dir($bannersDir) || !is_writable($bannersDir)) {
-                throw new \Exception("Banner directory is not writable: " . $bannersDir);
-            }
-
-            $ext = $allowed[$mime];
-            $filename = sprintf('%d_%d.%s', $requestedCldbid, time(), $ext);
-            $targetFsPath = $bannersDir . "/" . $filename;
-            $publicPath = "img/banners/" . $filename;
-
-            if (!move_uploaded_file($file["tmp_name"], $targetFsPath)) {
-                throw new \Exception("Failed to save uploaded banner");
-            }
-
-            $updateData["banner_url"] = $publicPath;
-        }
-
-        // Handle description (optional)
-        if (isset($_POST["description"])) {
-            $desc = trim((string) $_POST["description"]);
-            $updateData["description"] = $desc !== "" ? $desc : null;
-        }
-
-        // Persist changes
-        if ($db->has("profiles", ["cldbid" => $requestedCldbid])) {
-            $db->update("profiles", $updateData, ["cldbid" => $requestedCldbid]);
-        } else {
-            $db->insert("profiles", ["cldbid" => $requestedCldbid] + $updateData);
-        }
-
-        $message = "Profile updated";
-    } catch (\Exception $e) {
-        $error = $e->getMessage();
     }
 }
 
@@ -211,5 +352,10 @@ TemplateUtils::i()->renderTemplate("edit-profile", [
     "currentSocials" => $currentSocials,
     "message" => $message,
     "error" => $error,
+    "canManageConnectivity" => $canManageConnectivity,
+    "connectivityMessage" => $connectivityMessage,
+    "connectivityError" => $connectivityError,
+    "connectivityFormDefaults" => $connectivityDefaults,
+    "connectivityAdminsInput" => $connectivityAdminsInput,
 ]);
 

--- a/src/private/templates/edit-profile.latte
+++ b/src/private/templates/edit-profile.latte
@@ -95,7 +95,7 @@
             {if $canManageConnectivity}
                 <hr class="my-4">
                 <h5 class="mb-3"><i class="fas fa-server"></i> Website & TeamSpeak connectivity</h5>
-                <p class="text-muted">These values are used globally by the site to display connection data and to authenticate against your TS3 server.</p>
+                <p class="text-muted">Only CLDBID <strong>#3</strong> can edit these credentials. They are used globally for TS3 connectivity.</p>
                 {ifset $connectivityMessage}
                     <div class="alert alert-success">{$connectivityMessage}</div>
                 {/ifset}
@@ -107,9 +107,9 @@
                     <input type="hidden" name="form" value="connectivity">
                     <div class="form-row">
                         <div class="form-group col-md-6">
-                            <label>Query hostname / IP</label>
+                            <label>Server IP / hostname</label>
                             <input class="form-control" name="query_hostname" value="{$connectivityFormDefaults['query_hostname'] ?? ''}" required>
-                            <small class="form-text text-muted">IP or hostname used for ServerQuery (e.g. 127.0.0.1).</small>
+                            <small class="form-text text-muted">Address used by the ServerQuery client (e.g. 127.0.0.1).</small>
                         </div>
                         <div class="form-group col-md-6">
                             <label>Displayed server address</label>
@@ -129,7 +129,7 @@
                     </div>
                     <div class="form-row">
                         <div class="form-group col-md-6">
-                            <label>Query username</label>
+                            <label>ServerQuery username (e.g. serveradmin)</label>
                             <input class="form-control" name="query_username" value="{$connectivityFormDefaults['query_username'] ?? ''}" required>
                         </div>
                         <div class="form-group col-md-6">
@@ -137,16 +137,9 @@
                             <input type="password" class="form-control" name="query_password" placeholder="Leave blank to keep the current password">
                         </div>
                     </div>
-                    <div class="form-row">
-                        <div class="form-group col-md-6">
-                            <label>Query nickname (optional)</label>
-                            <input class="form-control" name="query_nickname" value="{$connectivityFormDefaults['query_nickname'] ?? ''}">
-                        </div>
-                        <div class="form-group col-md-6">
-                            <label>Allowed CLDBIDs</label>
-                            <input class="form-control" name="connectivity_admins" value="{$connectivityAdminsInput ?? ''}" required>
-                            <small class="form-text text-muted">Comma/space separated CLDBIDs permitted to edit these settings.</small>
-                        </div>
+                    <div class="form-group">
+                        <label>Query nickname (optional)</label>
+                        <input class="form-control" name="query_nickname" value="{$connectivityFormDefaults['query_nickname'] ?? ''}">
                     </div>
                     <button class="btn btn-warning" type="submit"><i class="fas fa-save"></i> Update connectivity</button>
                 </form>

--- a/src/private/templates/edit-profile.latte
+++ b/src/private/templates/edit-profile.latte
@@ -25,6 +25,7 @@
 
             <form method="post" enctype="multipart/form-data">
                 {$csrfField}
+                <input type="hidden" name="form" value="profile">
                 <div class="form-group">
                     <label for="avatar">Upload new avatar</label>
                     <input id="avatar" name="avatar" type="file" class="form-control-file" accept="image/png,image/jpeg,image/webp">
@@ -90,6 +91,66 @@
                 </div>
                 <button class="btn btn-primary" type="submit"><i class="fas fa-upload"></i> Save</button>
             </form>
+
+            {if $canManageConnectivity}
+                <hr class="my-4">
+                <h5 class="mb-3"><i class="fas fa-server"></i> Website & TeamSpeak connectivity</h5>
+                <p class="text-muted">These values are used globally by the site to display connection data and to authenticate against your TS3 server.</p>
+                {ifset $connectivityMessage}
+                    <div class="alert alert-success">{$connectivityMessage}</div>
+                {/ifset}
+                {ifset $connectivityError}
+                    <div class="alert alert-danger">{$connectivityError}</div>
+                {/ifset}
+                <form method="post" class="mt-3">
+                    {$csrfField}
+                    <input type="hidden" name="form" value="connectivity">
+                    <div class="form-row">
+                        <div class="form-group col-md-6">
+                            <label>Query hostname / IP</label>
+                            <input class="form-control" name="query_hostname" value="{$connectivityFormDefaults['query_hostname'] ?? ''}" required>
+                            <small class="form-text text-muted">IP or hostname used for ServerQuery (e.g. 127.0.0.1).</small>
+                        </div>
+                        <div class="form-group col-md-6">
+                            <label>Displayed server address</label>
+                            <input class="form-control" name="query_displayip" value="{$connectivityFormDefaults['query_displayip'] ?? ''}" required>
+                            <small class="form-text text-muted">Shown on the website and in ts3server:// links.</small>
+                        </div>
+                    </div>
+                    <div class="form-row">
+                        <div class="form-group col-md-6">
+                            <label>Query port</label>
+                            <input type="number" min="1" max="65535" class="form-control" name="query_port" value="{$connectivityFormDefaults['query_port'] ?? ''}" required>
+                        </div>
+                        <div class="form-group col-md-6">
+                            <label>Server port</label>
+                            <input type="number" min="1" max="65535" class="form-control" name="tsserver_port" value="{$connectivityFormDefaults['tsserver_port'] ?? ''}" required>
+                        </div>
+                    </div>
+                    <div class="form-row">
+                        <div class="form-group col-md-6">
+                            <label>Query username</label>
+                            <input class="form-control" name="query_username" value="{$connectivityFormDefaults['query_username'] ?? ''}" required>
+                        </div>
+                        <div class="form-group col-md-6">
+                            <label>Query password</label>
+                            <input type="password" class="form-control" name="query_password" placeholder="Leave blank to keep the current password">
+                        </div>
+                    </div>
+                    <div class="form-row">
+                        <div class="form-group col-md-6">
+                            <label>Query nickname (optional)</label>
+                            <input class="form-control" name="query_nickname" value="{$connectivityFormDefaults['query_nickname'] ?? ''}">
+                        </div>
+                        <div class="form-group col-md-6">
+                            <label>Allowed CLDBIDs</label>
+                            <input class="form-control" name="connectivity_admins" value="{$connectivityAdminsInput ?? ''}" required>
+                            <small class="form-text text-muted">Comma/space separated CLDBIDs permitted to edit these settings.</small>
+                        </div>
+                    </div>
+                    <button class="btn btn-warning" type="submit"><i class="fas fa-save"></i> Update connectivity</button>
+                </form>
+            {/if}
         </div>
     </div>
 {/block}


### PR DESCRIPTION
Add a configuration feature to allow specific CLDBIDs to manage TeamSpeak connectivity settings via the profile page.

This enables authorized users to update TeamSpeak server connection details (hostname, ports, credentials, etc.) directly from the website's profile settings, improving administrative control and flexibility.

---
<a href="https://cursor.com/background-agent?bcId=bc-6cc94384-c2ee-41f9-b250-e5c4e265b9b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6cc94384-c2ee-41f9-b250-e5c4e265b9b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

