### PR TITLE
Add teamspeak fields to profile edit

### DIFF
--- a/src/edit-profile.php
+++ b/src/edit-profile.php
@@ -55,8 +55,35 @@ try {
     exit;
 }
 
-$connectivityAdminCldbid = 3;
-$canManageConnectivity = $currentUserCldbid === $connectivityAdminCldbid;
+$connectivityAdminSetting = Config::get("connectivity_admin_cldbids", [3]);
+$allowAllConnectivityAdmins = false;
+$connectivityAdminIds = [];
+
+if ($connectivityAdminSetting === "*") {
+    $allowAllConnectivityAdmins = true;
+} elseif (is_array($connectivityAdminSetting)) {
+    foreach ($connectivityAdminSetting as $value) {
+        if (is_numeric($value)) {
+            $connectivityAdminIds[] = (int) $value;
+        }
+    }
+} elseif (is_string($connectivityAdminSetting)) {
+    $parts = preg_split('/[,\s]+/', $connectivityAdminSetting, -1, PREG_SPLIT_NO_EMPTY);
+    foreach ($parts as $part) {
+        if (is_numeric($part)) {
+            $connectivityAdminIds[] = (int) $part;
+        }
+    }
+} elseif (is_numeric($connectivityAdminSetting)) {
+    $connectivityAdminIds[] = (int) $connectivityAdminSetting;
+}
+
+$connectivityAdminIds = array_values(array_unique(array_filter($connectivityAdminIds, static function ($id) {
+    return is_int($id) && $id > 0;
+})));
+
+$canManageConnectivity = $allowAllConnectivityAdmins
+    || ($currentUserCldbid !== null && in_array($currentUserCldbid, $connectivityAdminIds, true));
 
 $connectivityDefaults = [
     "query_hostname" => (string) (Config::get("query_hostname") ?? ""),
@@ -303,5 +330,7 @@ TemplateUtils::i()->renderTemplate("edit-profile", [
     "connectivityMessage" => $connectivityMessage,
     "connectivityError" => $connectivityError,
     "connectivityFormDefaults" => $connectivityDefaults,
+    "connectivityAdminIds" => $connectivityAdminIds,
+    "connectivityAllowAll" => $allowAllConnectivityAdmins,
 ]);
 

--- a/src/private/config.local.php
+++ b/src/private/config.local.php
@@ -14,5 +14,9 @@ return [
 
     // Admin status will display members of server group ID 6
     'adminstatus_groups' => [6],
+
+    // CLDBIDs allowed to edit Website & TeamSpeak connectivity data via edit-profile.php.
+    // Replace 3 with your actual CLDBID(s).
+    'connectivity_admin_cldbids' => [3],
 ];
 

--- a/src/private/templates/edit-profile.latte
+++ b/src/private/templates/edit-profile.latte
@@ -92,10 +92,21 @@
                 <button class="btn btn-primary" type="submit"><i class="fas fa-upload"></i> Save</button>
             </form>
 
+            <hr class="my-4">
+            <h5 class="mb-3"><i class="fas fa-server"></i> Website & TeamSpeak connectivity</h5>
+            {var $connectivityAdminIds = $connectivityAdminIds ?? []}
+            {var $connectivityAdminCount = count($connectivityAdminIds)}
+            {var $connectivityAdminText = $connectivityAdminCount ? ('#' . implode(', #', $connectivityAdminIds)) : ''}
             {if $canManageConnectivity}
-                <hr class="my-4">
-                <h5 class="mb-3"><i class="fas fa-server"></i> Website & TeamSpeak connectivity</h5>
-                <p class="text-muted">Only CLDBID <strong>#3</strong> can edit these credentials. They are used globally for TS3 connectivity.</p>
+                <p class="text-muted">
+                    {if $connectivityAllowAll}
+                        Any logged-in user can edit these credentials. They are used globally for TS3 connectivity.
+                    {elseif $connectivityAdminCount}
+                        Only CLDBID{if $connectivityAdminCount > 1}s{/if} <strong>{$connectivityAdminText}</strong> can edit these credentials. They are used globally for TS3 connectivity.
+                    {else}
+                        No CLDBID has been granted access to edit these credentials yet. Update the <code>connectivity_admin_cldbids</code> config to allow access.
+                    {/if}
+                </p>
                 {ifset $connectivityMessage}
                     <div class="alert alert-success">{$connectivityMessage}</div>
                 {/ifset}
@@ -143,6 +154,16 @@
                     </div>
                     <button class="btn btn-warning" type="submit"><i class="fas fa-save"></i> Update connectivity</button>
                 </form>
+            {else}
+                <div class="alert alert-info">
+                    {if $connectivityAllowAll}
+                        These credentials should be editable by any logged-in user, but your session does not currently have access. Try refreshing or logging in again.
+                    {elseif $connectivityAdminCount}
+                        Only CLDBID{if $connectivityAdminCount > 1}s{/if} <strong>{$connectivityAdminText}</strong> can edit these credentials. Your CLDBID is <strong>#{$cldbid}</strong>. Ask an administrator to add your ID to the <code>connectivity_admin_cldbids</code> config if you require access.
+                    {else}
+                        Connectivity editing is disabled until at least one CLDBID is configured via <code>connectivity_admin_cldbids</code>.
+                    {/if}
+                </div>
             {/if}
         </div>
     </div>


### PR DESCRIPTION
Implement configurable access control for TeamSpeak connectivity settings on the edit profile page to allow administrators to define which CLDBIDs can manage this data.

---
<a href="https://cursor.com/background-agent?bcId=bc-3141900f-1fa3-4534-841e-a5f0a28c0611"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3141900f-1fa3-4534-841e-a5f0a28c0611"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

