### PR TITLE
Add discord status widget to profile

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -654,6 +654,23 @@ table.dataTable > tbody > tr.child td.child {
     gap: 0.2rem;
 }
 
+.discord-widget--loading .discord-widget__status-text::after {
+    content: "Updating...";
+    margin-left: 0.35rem;
+    font-size: 0.7rem;
+    color: #b9bbbe;
+    text-transform: none;
+    letter-spacing: normal;
+}
+
+.discord-widget--error .discord-widget__status-text {
+    color: #ff9aa2;
+}
+
+.discord-widget--error .discord-widget__username {
+    color: #ffbac7;
+}
+
 @media (max-width: 991px) {
     .discord-widget {
         margin-top: 0.5rem;

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -564,3 +564,98 @@ table.dataTable > tbody > tr.child td.child {
     70% { box-shadow: 0 0 0 8px rgba(0,0,0,0); }
     100% { box-shadow: 0 0 0 0 rgba(0,0,0,0); }
 }
+
+/* Discord widget */
+.profile-description-row {
+    align-items: stretch;
+}
+
+.discord-widget {
+    background: #23272a;
+    color: #fff;
+    border-radius: 12px;
+    padding: 1rem;
+    box-shadow: 0 12px 24px rgba(0, 0, 0, 0.15);
+    height: 100%;
+}
+
+.discord-widget.card-accent {
+    border: none;
+}
+
+.discord-widget__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    text-transform: uppercase;
+    font-size: 0.8rem;
+    letter-spacing: 0.05em;
+    color: #b9bbbe;
+}
+
+.discord-widget__status {
+    display: flex;
+    align-items: center;
+    font-weight: 600;
+    color: #fff;
+    font-size: 0.85rem;
+}
+
+.discord-widget__status-dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    display: inline-block;
+    margin-right: 0.35rem;
+    background: #747f8d;
+}
+
+.discord-widget__status-dot.online { background: #43b581; }
+.discord-widget__status-dot.idle { background: #faa61a; }
+.discord-widget__status-dot.dnd { background: #f04747; }
+.discord-widget__status-dot.offline { background: #747f8d; }
+
+.discord-widget__body {
+    display: flex;
+    align-items: center;
+    text-decoration: none;
+    color: inherit;
+    margin-top: 0.75rem;
+}
+
+.discord-widget__body:hover {
+    text-decoration: none;
+    color: #fff;
+}
+
+.discord-widget__avatar {
+    width: 56px;
+    height: 56px;
+    border-radius: 50%;
+    margin-right: 0.85rem;
+    object-fit: cover;
+    border: 2px solid rgba(255, 255, 255, 0.15);
+    box-shadow: 0 3px 10px rgba(0,0,0,0.25);
+}
+
+.discord-widget__display-name {
+    font-weight: 600;
+    font-size: 1rem;
+}
+
+.discord-widget__username {
+    color: #b9bbbe;
+    font-size: 0.85rem;
+}
+
+.discord-widget__meta {
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+}
+
+@media (max-width: 991px) {
+    .discord-widget {
+        margin-top: 0.5rem;
+    }
+}

--- a/src/js/script.js
+++ b/src/js/script.js
@@ -110,6 +110,8 @@ $(function () {
             }
         });
     }
+
+    initDiscordWidgets();
 });
 
 function timestampToDate(timestamp, full) {
@@ -169,4 +171,134 @@ function copyTextToClipboard(text) {
 
     document.body.removeChild(textArea)
     return success
+}
+
+function initDiscordWidgets() {
+    var widgets = document.querySelectorAll('.discord-widget[data-discord-user-id]');
+
+    if (!widgets.length || typeof window.fetch !== 'function') {
+        return;
+    }
+
+    widgets.forEach(function(widget) {
+        if (widget.classList.contains('discord-widget--has-data')) {
+            return;
+        }
+
+        var userId = widget.getAttribute('data-discord-user-id');
+        if (!userId) {
+            return;
+        }
+
+        widget.classList.remove('discord-widget--error');
+        widget.classList.add('discord-widget--loading');
+
+        fetch('https://api.lanyard.rest/v1/users/' + encodeURIComponent(userId))
+            .then(function(resp) {
+                if (!resp.ok) {
+                    throw new Error('HTTP ' + resp.status);
+                }
+                return resp.json();
+            })
+            .then(function(payload) {
+                if (!payload || !payload.success || !payload.data || !payload.data.discord_user) {
+                    throw new Error('Invalid payload');
+                }
+                updateDiscordWidgetFromPayload(widget, payload.data, userId);
+            })
+            .catch(function() {
+                widget.classList.add('discord-widget--error');
+            })
+            .then(function() {
+                widget.classList.remove('discord-widget--loading');
+            });
+    });
+}
+
+function updateDiscordWidgetFromPayload(widget, payload, fallbackUserId) {
+    if (!payload || !widget) {
+        return;
+    }
+
+    var statusMap = {
+        online: { label: 'Online', className: 'online' },
+        idle: { label: 'Away', className: 'idle' },
+        dnd: { label: 'Do Not Disturb', className: 'dnd' },
+        offline: { label: 'Offline', className: 'offline' },
+        invisible: { label: 'Offline', className: 'offline' }
+    };
+
+    var statusKey = (payload.discord_status || 'offline').toLowerCase();
+    var statusInfo = statusMap[statusKey] || statusMap.offline;
+
+    var statusDot = widget.querySelector('[data-discord-role="status-dot"]');
+    if (statusDot) {
+        statusDot.className = 'discord-widget__status-dot ' + statusInfo.className;
+    }
+
+    var statusText = widget.querySelector('[data-discord-role="status-text"]');
+    if (statusText) {
+        statusText.textContent = statusInfo.label;
+    }
+
+    var discordUser = payload.discord_user || {};
+    var resolvedUserId = discordUser.id || fallbackUserId;
+
+    var avatarEl = widget.querySelector('[data-discord-role="avatar"]');
+    if (avatarEl) {
+        avatarEl.src = getDiscordAvatarUrl(resolvedUserId, discordUser.avatar, discordUser.discriminator);
+    }
+
+    var displayEl = widget.querySelector('[data-discord-role="display"]');
+    if (displayEl) {
+        displayEl.textContent = discordUser.global_name || discordUser.username || 'Discord user';
+    }
+
+    var usernameEl = widget.querySelector('[data-discord-role="username"]');
+    if (usernameEl) {
+        usernameEl.textContent = formatDiscordUsernameTag(discordUser, resolvedUserId);
+    }
+
+    var profileLink = widget.querySelector('[data-discord-role="profile-link"]');
+    if (profileLink) {
+        profileLink.href = 'https://discord.com/users/' + encodeURIComponent(resolvedUserId);
+    }
+
+    widget.classList.add('discord-widget--has-data');
+    widget.classList.remove('discord-widget--error');
+}
+
+function getDiscordAvatarUrl(userId, avatarHash, discriminator) {
+    if (avatarHash) {
+        return 'https://cdn.discordapp.com/avatars/' + encodeURIComponent(userId) + '/' + encodeURIComponent(avatarHash) + '.png?size=128';
+    }
+
+    var discNumber = parseInt(discriminator, 10);
+    if (isNaN(discNumber) || discNumber < 0) {
+        discNumber = 0;
+    }
+
+    return 'https://cdn.discordapp.com/embed/avatars/' + (discNumber % 5) + '.png';
+}
+
+function formatDiscordUsernameTag(discordUser, fallbackUserId) {
+    if (!discordUser || !discordUser.username) {
+        return 'ID: ' + fallbackUserId;
+    }
+
+    var discriminator = discordUser.discriminator;
+    if (!discriminator || discriminator === '0') {
+        var username = discordUser.username;
+        if (username.indexOf('@') === 0) {
+            return username;
+        }
+        return '@' + username;
+    }
+
+    var padded = discriminator.toString();
+    while (padded.length < 4) {
+        padded = '0' + padded;
+    }
+
+    return discordUser.username + '#' + padded;
 }

--- a/src/private/templates/edit-profile.latte
+++ b/src/private/templates/edit-profile.latte
@@ -98,8 +98,8 @@
                             <input class="form-control" name="twitch" placeholder="https://twitch.tv/username" value="{$currentSocials['twitch'] ?? ''}">
                         </div>
                         <div class="form-group">
-                            <label><i class="fab fa-discord"></i> Discord</label>
-                            <input class="form-control" name="discord" placeholder="https://discord.gg/invite-or-username" value="{$currentSocials['discord'] ?? ''}">
+                            <label><i class="fab fa-discord"></i> Discord ID</label>
+                            <input class="form-control" name="discord" placeholder="Discord user ID or https://discord.com/users/123" value="{$currentSocials['discord'] ?? ''}">
                         </div>
                     </div>
                 </div>

--- a/src/private/templates/profile.latte
+++ b/src/private/templates/profile.latte
@@ -91,32 +91,38 @@
             </div>
             <hr>
             <p><strong>Description</strong></p>
+            {var $hasDiscord = $discordUserId ?? null}
             <div class="row profile-description-row">
-                <div class="col-12{ifset $discordPresence} col-lg-8{/ifset}">
+                <div class="col-12{if $hasDiscord} col-lg-8{/if}">
                     <div class="desc">{ifset $profile["description"]}{$profile["description"]|noescape}{else}<em>No description</em>{/ifset}</div>
                 </div>
-                {ifset $discordPresence}
+                {if $hasDiscord}
+                    {var $discordWidgetAvatar = $discordPresence ? $discordPresence["avatarUrl"] : 'https://cdn.discordapp.com/embed/avatars/0.png'}
+                    {var $discordWidgetStatusKey = $discordPresence ? $discordPresence["statusKey"] : 'offline'}
+                    {var $discordWidgetStatusLabel = $discordPresence ? $discordPresence["statusLabel"] : 'Status unavailable'}
+                    {var $discordWidgetDisplay = $discordPresence ? $discordPresence["displayName"] : 'Discord status unavailable'}
+                    {var $discordWidgetUsername = ($discordPresence && isset($discordPresence["usernameTag"])) ? $discordPresence["usernameTag"] : ('ID: ' . $discordUserId)}
+                    {var $discordWidgetProfileUrl = $discordPresence ? $discordPresence["profileUrl"] : ("https://discord.com/users/" . $discordUserId)}
                     <div class="col-12 col-lg-4 mt-3 mt-lg-0">
-                        <div class="discord-widget card-accent">
+                        <div class="discord-widget card-accent{if $discordPresence} discord-widget--has-data{/if}" data-discord-user-id="{$discordUserId}">
                             <div class="discord-widget__header">
                                 <span class="discord-widget__label"><i class="fab fa-discord"></i> Discord</span>
                                 <span class="discord-widget__status">
-                                    <span class="discord-widget__status-dot {$discordPresence["statusKey"]}"></span>
-                                    {$discordPresence["statusLabel"]}
+                                    <span class="discord-widget__status-dot {$discordWidgetStatusKey}" data-discord-role="status-dot"></span>
+                                    <span class="discord-widget__status-text" data-discord-role="status-text">{$discordWidgetStatusLabel}</span>
                                 </span>
                             </div>
-                            <a href="{$discordPresence["profileUrl"]}" target="_blank" rel="noopener" class="discord-widget__body">
-                                <img src="{$discordPresence["avatarUrl"]}" alt="Discord avatar" class="discord-widget__avatar">
+                            <a href="{$discordWidgetProfileUrl}" target="_blank" rel="noopener"
+                               class="discord-widget__body" data-discord-role="profile-link">
+                                <img src="{$discordWidgetAvatar}" alt="Discord avatar" class="discord-widget__avatar" data-discord-role="avatar">
                                 <div class="discord-widget__meta">
-                                    <div class="discord-widget__display-name">{$discordPresence["displayName"]}</div>
-                                    {ifset $discordPresence["usernameTag"]}
-                                        <div class="discord-widget__username">{$discordPresence["usernameTag"]}</div>
-                                    {/ifset}
+                                    <div class="discord-widget__display-name" data-discord-role="display">{$discordWidgetDisplay}</div>
+                                    <div class="discord-widget__username" data-discord-role="username">{$discordWidgetUsername}</div>
                                 </div>
                             </a>
                         </div>
                     </div>
-                {/ifset}
+                {/if}
             </div>
         </div>
     </div>

--- a/src/private/templates/profile.latte
+++ b/src/private/templates/profile.latte
@@ -91,7 +91,33 @@
             </div>
             <hr>
             <p><strong>Description</strong></p>
-            <div class="desc">{ifset $profile["description"]}{$profile["description"]|noescape}{else}<em>No description</em>{/ifset}</div>
+            <div class="row profile-description-row">
+                <div class="col-12{ifset $discordPresence} col-lg-8{/ifset}">
+                    <div class="desc">{ifset $profile["description"]}{$profile["description"]|noescape}{else}<em>No description</em>{/ifset}</div>
+                </div>
+                {ifset $discordPresence}
+                    <div class="col-12 col-lg-4 mt-3 mt-lg-0">
+                        <div class="discord-widget card-accent">
+                            <div class="discord-widget__header">
+                                <span class="discord-widget__label"><i class="fab fa-discord"></i> Discord</span>
+                                <span class="discord-widget__status">
+                                    <span class="discord-widget__status-dot {$discordPresence["statusKey"]}"></span>
+                                    {$discordPresence["statusLabel"]}
+                                </span>
+                            </div>
+                            <a href="{$discordPresence["profileUrl"]}" target="_blank" rel="noopener" class="discord-widget__body">
+                                <img src="{$discordPresence["avatarUrl"]}" alt="Discord avatar" class="discord-widget__avatar">
+                                <div class="discord-widget__meta">
+                                    <div class="discord-widget__display-name">{$discordPresence["displayName"]}</div>
+                                    {ifset $discordPresence["usernameTag"]}
+                                        <div class="discord-widget__username">{$discordPresence["usernameTag"]}</div>
+                                    {/ifset}
+                                </div>
+                            </a>
+                        </div>
+                    </div>
+                {/ifset}
+            </div>
         </div>
     </div>
 

--- a/src/profile.php
+++ b/src/profile.php
@@ -10,6 +10,136 @@ use Wruczek\PhpFileCache\PhpFileCache;
 
 require_once __DIR__ . "/private/php/load.php";
 
+/**
+ * Attempts to extract a Discord user ID (snowflake) from optional profile input.
+ */
+function profile_extract_discord_user_id(?string $input): ?string
+{
+    if ($input === null) {
+        return null;
+    }
+
+    $value = trim((string) $input);
+    if ($value === '') {
+        return null;
+    }
+
+    if (preg_match('#discord(?:app)?\.com/(?:users|user)/(\d{15,21})#i', $value, $matches)) {
+        return $matches[1];
+    }
+
+    if (preg_match('/^\d{15,21}$/', $value)) {
+        return $value;
+    }
+
+    if (preg_match('/\b\d{15,21}\b/', $value, $matches)) {
+        return $matches[0];
+    }
+
+    return null;
+}
+
+/**
+ * Fetches Discord presence details using the public Lanyard API.
+ */
+function profile_fetch_discord_presence(string $userId): ?array
+{
+    $url = "https://api.lanyard.rest/v1/users/" . rawurlencode($userId);
+    $headers = [
+        "Accept: application/json",
+        "User-Agent: ts-website-profile-widget/1.0",
+    ];
+    $body = null;
+
+    if (function_exists('curl_init')) {
+        $ch = curl_init($url);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_TIMEOUT, 4);
+        curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
+        $response = curl_exec($ch);
+        $statusCode = (int) curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        if ($response !== false && $statusCode >= 200 && $statusCode < 300) {
+            $body = $response;
+        }
+        curl_close($ch);
+    }
+
+    if ($body === null) {
+        $context = stream_context_create([
+            'http' => [
+                'method' => 'GET',
+                'timeout' => 4,
+                'header' => implode("\r\n", $headers) . "\r\n",
+            ],
+        ]);
+        $fallbackResponse = @file_get_contents($url, false, $context);
+        if ($fallbackResponse !== false) {
+            $body = $fallbackResponse;
+        }
+    }
+
+    if ($body === null) {
+        return null;
+    }
+
+    $decoded = json_decode($body, true);
+    if (!is_array($decoded) || empty($decoded["success"]) || !isset($decoded["data"]) || !is_array($decoded["data"])) {
+        return null;
+    }
+
+    $data = $decoded["data"];
+    if (!isset($data["discord_user"]) || !is_array($data["discord_user"])) {
+        return null;
+    }
+
+    $discordUser = $data["discord_user"];
+    $statusRaw = isset($data["discord_status"]) ? strtolower((string) $data["discord_status"]) : "offline";
+    $statusMap = [
+        "online" => ["label" => "Online", "class" => "online"],
+        "dnd" => ["label" => "Do Not Disturb", "class" => "dnd"],
+        "idle" => ["label" => "Away", "class" => "idle"],
+        "offline" => ["label" => "Offline", "class" => "offline"],
+        "invisible" => ["label" => "Offline", "class" => "offline"],
+    ];
+    $statusInfo = $statusMap[$statusRaw] ?? $statusMap["offline"];
+
+    $avatarUrl = null;
+    if (!empty($discordUser["avatar"])) {
+        $avatarUrl = sprintf(
+            "https://cdn.discordapp.com/avatars/%s/%s.png?size=128",
+            rawurlencode($userId),
+            rawurlencode($discordUser["avatar"])
+        );
+    } else {
+        $discriminator = isset($discordUser["discriminator"]) ? (int) $discordUser["discriminator"] : 0;
+        $fallbackIndex = $discriminator % 5;
+        $avatarUrl = sprintf("https://cdn.discordapp.com/embed/avatars/%d.png", $fallbackIndex);
+    }
+
+    $username = isset($discordUser["username"]) ? (string) $discordUser["username"] : null;
+    $discriminator = isset($discordUser["discriminator"]) ? (string) $discordUser["discriminator"] : null;
+    $usernameTag = null;
+    if ($username !== null) {
+        if ($discriminator !== null && $discriminator !== '' && $discriminator !== '0') {
+            $usernameTag = sprintf('%s#%s', $username, str_pad($discriminator, 4, '0', STR_PAD_LEFT));
+        } else {
+            $usernameTag = '@' . ltrim($username, '@');
+        }
+    }
+
+    $displayName = $discordUser["global_name"] ?? $username ?? "Discord user";
+
+    return [
+        "userId" => $userId,
+        "displayName" => $displayName,
+        "usernameTag" => $usernameTag,
+        "avatarUrl" => $avatarUrl,
+        "statusKey" => $statusInfo["class"],
+        "statusLabel" => $statusInfo["label"],
+        "profileUrl" => "https://discord.com/users/" . rawurlencode($userId),
+    ];
+}
+
 $cldbid = isset($_GET["cldbid"]) ? (int) $_GET["cldbid"] : 0;
 
 if ($cldbid <= 0) {
@@ -379,6 +509,14 @@ if ($dbProfile && !empty($dbProfile["socials_json"])) {
         $socials = $decoded;
     }
 }
+$discordPresence = null;
+$discordUserId = null;
+if (isset($socials["discord"])) {
+    $discordUserId = profile_extract_discord_user_id($socials["discord"]);
+    if ($discordUserId !== null) {
+        $discordPresence = profile_fetch_discord_presence($discordUserId);
+    }
+}
 
 // Prepare social items with icon classes for template
 $socialIconMap = [
@@ -419,6 +557,7 @@ $renderData = [
     "currentChannelId" => isset($profileData['cid']) ? (int) $profileData['cid'] : null,
     "rankImageUrl" => $rankImageUrl,
     "rankLevel" => $rankLevel,
+    "discordPresence" => $discordPresence,
 ];
 
 // Compute last seen text for offline users

--- a/src/profile.php
+++ b/src/profile.php
@@ -558,6 +558,7 @@ $renderData = [
     "rankImageUrl" => $rankImageUrl,
     "rankLevel" => $rankLevel,
     "discordPresence" => $discordPresence,
+    "discordUserId" => $discordUserId,
 ];
 
 // Compute last seen text for offline users


### PR DESCRIPTION
Add a Discord presence widget to user profiles to display real-time Discord status, avatar, and username by fetching data from the Lanyard API.

---
<a href="https://cursor.com/background-agent?bcId=bc-4153362d-4de2-47ac-b6fc-a48b5e598708"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4153362d-4de2-47ac-b6fc-a48b5e598708"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

