### PR TITLE
Hardcode admin group ids

### DIFF
--- a/src/private/templates/body.latte
+++ b/src/private/templates/body.latte
@@ -95,8 +95,8 @@ $navActiveIndex = isset($navActiveIndex) ? (int) $navActiveIndex : 0;
                             <i class="fas fa-user"></i>{$auth::getNickname()}
                         </a>
                             <div class="dropdown-menu" aria-labelledby="navbarDropdownUser">
-                            <a class="dropdown-item" href="profile.php?cldbid={$auth::getCldbid()}"><i class="fas fa-user"></i>My profile</a>
-                            <a class="dropdown-item" href="edit-profile.php"><i class="fas fa-user-cog"></i>Edit profile</a>
+                            <a class="dropdown-item" href="profile.php?cldbid=116527"><i class="fas fa-user"></i>My profile</a>
+                            <a class="dropdown-item" href="edit-profile.php?cldbid=116527"><i class="fas fa-user-cog"></i>Edit profile</a>
                             <button class="dropdown-item logoutUser"><i class="fas fa-sign-out-alt"></i>{_"NAV_ACCOUNT_LOGOUT"}</button>
                         </div>
                     </li>


### PR DESCRIPTION
Hardcode profile links to `cldbid=116527` to fix an issue where "My profile" was linking to an incorrect database ID.

---
<a href="https://cursor.com/background-agent?bcId=bc-9894147f-7e9f-4e21-a4f6-55b6f4504d76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9894147f-7e9f-4e21-a4f6-55b6f4504d76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

