### PR TITLE
Profile connection status display

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -446,6 +446,7 @@ table.dataTable > tbody > tr.child td.child {
     display: flex;
     align-items: center;
     justify-content: center;
+    flex-shrink: 0;
 }
 
 .avatar-preview .avatar-img {
@@ -465,8 +466,9 @@ table.dataTable > tbody > tr.child td.child {
     object-fit: contain;
     pointer-events: none;
     user-select: none;
-    top: 0;
-    left: 0;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
 }
 
 .avatar-preview--sm {
@@ -563,4 +565,48 @@ table.dataTable > tbody > tr.child td.child {
     0% { box-shadow: 0 0 0 0 rgba(0,0,0,0.3); }
     70% { box-shadow: 0 0 0 8px rgba(0,0,0,0); }
     100% { box-shadow: 0 0 0 0 rgba(0,0,0,0); }
+}
+
+/* Mobile responsive fixes for avatar and border overlay */
+@media (max-width: 768px) {
+    .steamlike-header .avatar-and-meta {
+        flex-direction: column;
+        align-items: center !important;
+        text-align: center;
+    }
+    
+    .steamlike-header .avatar-and-meta > div:first-child {
+        flex-direction: column;
+        align-items: center;
+    }
+    
+    .steamlike-header .meta {
+        margin-left: 0 !important;
+        margin-top: 1rem;
+    }
+    
+    .avatar-preview {
+        margin: 0 auto;
+    }
+}
+
+@media (max-width: 576px) {
+    .steamlike-header .cover {
+        height: 120px;
+    }
+    
+    .avatar-preview {
+        width: 100px;
+        height: 100px;
+    }
+    
+    .avatar-preview .avatar-img {
+        width: 80px;
+        height: 80px;
+    }
+    
+    .avatar-preview .avatar-border-overlay {
+        width: 100px;
+        height: 100px;
+    }
 }

--- a/src/private/php/Utils/AvatarBorderUtils.php
+++ b/src/private/php/Utils/AvatarBorderUtils.php
@@ -7,16 +7,21 @@ namespace Wruczek\TSWebsite\Utils;
  */
 class AvatarBorderUtils {
 
-    private const DEFAULT_KEY = 'radiant-vortex';
+    private const DEFAULT_KEY = 'none';
 
     /**
      * @var array<string, array{label: string, url: string, description: string}>
      */
     private const BORDER_OPTIONS = [
+        'none' => [
+            'label' => 'None',
+            'url' => '',
+            'description' => 'No avatar border overlay.',
+        ],
         'radiant-vortex' => [
             'label' => 'Radiant Vortex',
             'url' => 'https://shared.fastly.steamstatic.com/community_assets/images/items/1145350/7e753023f517ba01d4fd5d4031d69addb68751f5.png',
-            'description' => 'Default purple lightning overlay featured on all avatars.',
+            'description' => 'Purple lightning overlay with energy aura.',
         ],
         'ember-crown' => [
             'label' => 'Ember Crown',

--- a/src/private/templates/edit-profile.latte
+++ b/src/private/templates/edit-profile.latte
@@ -18,7 +18,9 @@
             <div class="d-flex align-items-center mb-3">
                 <div class="avatar-preview mr-3">
                     <img src="{$currentAvatar}" alt="current avatar" class="avatar-img">
-                    <img src="{$currentAvatarBorderUrl}" alt="selected border" class="avatar-border-overlay">
+                    {if $currentAvatarBorderUrl}
+                        <img src="{$currentAvatarBorderUrl}" alt="selected border" class="avatar-border-overlay">
+                    {/if}
                 </div>
                 <div>
                     <div class="text-muted">Current avatar &amp; border</div>
@@ -41,7 +43,9 @@
                                 <div class="border-option__body">
                                     <div class="avatar-preview avatar-preview--sm mb-2">
                                         <img src="{$currentAvatar}" alt="preview avatar" class="avatar-img">
-                                        <img src="{$border['url']}" alt="{$border['label']} border" class="avatar-border-overlay">
+                                        {if $border['url']}
+                                            <img src="{$border['url']}" alt="{$border['label']} border" class="avatar-border-overlay">
+                                        {/if}
                                     </div>
                                     <div class="font-weight-bold">{$border['label']}</div>
                                     <small class="text-muted d-block mt-1">{$border['description']}</small>

--- a/src/private/templates/profile.latte
+++ b/src/private/templates/profile.latte
@@ -8,7 +8,9 @@
             <div class="d-flex align-items-center">
                 <div class="avatar avatar-preview">
                     <img src="{$avatarUrl}" alt="avatar" class="avatar-img">
-                    <img src="{$avatarBorderUrl}" alt="avatar border" class="avatar-border-overlay">
+                    {if $avatarBorderUrl}
+                        <img src="{$avatarBorderUrl}" alt="avatar border" class="avatar-border-overlay">
+                    {/if}
                 </div>
                 <div class="meta ml-3">
                     <h3 class="nickname mb-1 d-flex align-items-center">

--- a/src/private/templates/profile.latte
+++ b/src/private/templates/profile.latte
@@ -13,19 +13,21 @@
                     {/if}
                 </div>
                 <div class="meta ml-3">
-                    <h3 class="nickname mb-1 d-flex align-items-center">
+                    <h3 class="nickname mb-1 d-flex align-items-center{if $nicknameStyle} nickname-{$nicknameStyle}{/if}">
                         <span>{$profile["nickname"] ?? ("User #" . $profile["cldbid"]) }</span>
                         {ifset $groups}
                             {foreach $groups as $g}
-                                {if $g['sgid'] === 6}
-                                    <img src="https://cdn3.emoji.gg/emojis/28948-staff.png" alt="Group 6" class="ml-2" style="height:24px;width:24px;object-fit:contain;vertical-align:middle;" data-toggle="tooltip" title="Group 6">
-                                    {breakIf true}
+                                {if $g['sgid'] === 532 && $g['iconid']}
+                                    <img src="api/geticon.php?iconid={$g['iconid']}" alt="{$g['name']}" class="ml-2" style="height:16px;width:16px;object-fit:contain;vertical-align:middle;" data-toggle="tooltip" title="{$g['name']}">
+                                {/if}
+                                {if $g['sgid'] === 556 && $g['iconid']}
+                                    <img src="api/geticon.php?iconid={$g['iconid']}" alt="{$g['name']}" class="ml-2" style="height:16px;width:16px;object-fit:contain;vertical-align:middle;" data-toggle="tooltip" title="{$g['name']}">
                                 {/if}
                             {/foreach}
                         {/ifset}
                     </h3>
                     <div class="subtext">
-                        <span><i class="fas fa-id-badge"></i> CLDBID: {$profile["cldbid"]}</span>
+                        <span>#{$profile["cldbid"]}</span>
                         {ifset $profile["cluid"]}
                             <span class="ml-2"><i class="fas fa-fingerprint"></i> {$profile["cluid"]}</span>
                         {/ifset}

--- a/src/private/templates/profile.latte
+++ b/src/private/templates/profile.latte
@@ -84,9 +84,15 @@
                     <p><strong>Version:</strong> {$profile["version"] ?? '-'}</p>
                 </div>
                 <div class="col-md-6">
-                    <p><strong>Total connections:</strong> {ifset $profile["totalconnections"]}{$profile["totalconnections"]}{else}-{/ifset}</p>
+                    <p><strong>Total connections:</strong> {$profile["totalconnections"] ?? '-'}</p>
                     <p><strong>First connected:</strong> {$profile["first_connected_human"] ?? '-'}</p>
-                    <p><strong>Last online:</strong> {$profile["last_online_human"] ?? '-'}</p>
+                    <p><strong>Last online:</strong>
+                        {if $isOnline}
+                            <span class="status-dot green"></span> Now
+                        {else}
+                            {$profile["last_online_human"] ?? '-'}
+                        {/if}
+                    </p>
                 </div>
             </div>
             <hr>

--- a/src/profile.php
+++ b/src/profile.php
@@ -149,8 +149,15 @@ if ($onlineClient) {
                 $parts[] = $seconds . " second" . ($seconds !== 1 ? "s" : "");
                 $profileData["online_since_text"] = implode(" ", $parts);
             }
-            if (isset($live["client_totalconnections"])) {
+            // Get detailed client info including totalconnections, created, lastconnected
+            if (isset($live["client_totalconnections"]) && is_numeric($live["client_totalconnections"])) {
                 $profileData["totalconnections"] = (int) $live["client_totalconnections"]; // live value preferred when online
+            }
+            if (isset($live["client_created"]) && is_numeric($live["client_created"])) {
+                $profileData["created_ts"] = (int) $live["client_created"]; // override with live data
+            }
+            if (isset($live["client_lastconnected"]) && is_numeric($live["client_lastconnected"])) {
+                $profileData["lastconnected_ts"] = (int) $live["client_lastconnected"]; // override with live data
             }
             // Bandwidth last minute totals (bytes) -> compute per-second and human readable
             if (isset($live["connection_bandwidth_sent_last_minute_total"])) {
@@ -233,25 +240,29 @@ if (!$isOnline) {
     }
 }
 
+// Fetch DB-stored fields FIRST before we update database
+$dbProfile = $db->get("profiles", "*", ["cldbid" => $cldbid]);
+
 // Persist to DB (upsert) - do not overwrite existing values with NULLs
 // This updates the database with the latest data every time a profile is viewed
 // ensuring that data like totalconnections, created_ts, lastconnected_ts persist when user goes offline
-try {
-    if ($db->has("profiles", ["cldbid" => $cldbid])) {
-        $updateData = array_filter($profileData, function ($v) { return $v !== null; });
-        if (!empty($updateData)) {
-            $db->update("profiles", $updateData, ["cldbid" => $cldbid]);
+// Only save if we have new data (user is online or we got fresh TS data)
+if ($isOnline || $tsInfo) {
+    try {
+        if ($dbProfile) {
+            $updateData = array_filter($profileData, function ($v) { return $v !== null; });
+            if (!empty($updateData)) {
+                $db->update("profiles", $updateData, ["cldbid" => $cldbid]);
+            }
+        } else {
+            $db->insert("profiles", $profileData);
         }
-    } else {
-        $db->insert("profiles", $profileData);
+    } catch (\Exception $e) {
+        // Non-fatal for rendering
     }
-} catch (\Exception $e) {
-    // Non-fatal for rendering
 }
 
 // Prepare data for template
-// Fetch DB-stored fields (e.g., avatar)
-$dbProfile = $db->get("profiles", "*", ["cldbid" => $cldbid]);
 
 // Resolve server group details
 $groupsDetailed = [];
@@ -335,8 +346,8 @@ if ((empty($profileData["servergroups"]) || $profileData["servergroups"] === nul
 // Preserve timestamps and total connections always (even when offline)
 $preserveNumericKeys = ["created_ts", "lastconnected_ts", "totalconnections"];
 foreach ($preserveNumericKeys as $k) {
-    if (!isset($profileData[$k]) || $profileData[$k] === null) {
-        if ($dbProfile && isset($dbProfile[$k]) && $dbProfile[$k] !== null) {
+    if (!isset($profileData[$k]) || $profileData[$k] === null || $profileData[$k] === '') {
+        if ($dbProfile && isset($dbProfile[$k]) && $dbProfile[$k] !== null && $dbProfile[$k] !== '') {
             $profileData[$k] = is_numeric($dbProfile[$k]) ? (int) $dbProfile[$k] : $dbProfile[$k];
         }
     }

--- a/src/profile.php
+++ b/src/profile.php
@@ -186,6 +186,8 @@ if ($isOnline) {
             "version" => $profileData["version"] ?? null,
             "platform" => $profileData["platform"] ?? null,
             "totalconnections" => $profileData["totalconnections"] ?? null,
+            "created_ts" => $profileData["created_ts"] ?? null,
+            "lastconnected_ts" => $profileData["lastconnected_ts"] ?? null,
             "bw_up_h" => $profileData["bw_up_h"] ?? null,
             "bw_down_h" => $profileData["bw_down_h"] ?? null,
             "nickname" => $profileData["nickname"] ?? null,
@@ -232,6 +234,8 @@ if (!$isOnline) {
 }
 
 // Persist to DB (upsert) - do not overwrite existing values with NULLs
+// This updates the database with the latest data every time a profile is viewed
+// ensuring that data like totalconnections, created_ts, lastconnected_ts persist when user goes offline
 try {
     if ($db->has("profiles", ["cldbid" => $cldbid])) {
         $updateData = array_filter($profileData, function ($v) { return $v !== null; });
@@ -353,14 +357,14 @@ if (!$isOnline) {
         $lastSeenCache = new PhpFileCache(__CACHE_DIR, "profile_last_seen");
         $last = $lastSeenCache->retrieve("u_" . (int) $cldbid);
         if (is_array($last)) {
-            foreach (["country", "version", "platform", "bw_up_h", "bw_down_h", "nickname", "totalconnections"] as $k) {
+            foreach (["country", "version", "platform", "bw_up_h", "bw_down_h", "nickname", "totalconnections", "created_ts", "lastconnected_ts"] as $k) {
                 if (!isset($profileData[$k]) || $profileData[$k] === null || $profileData[$k] === '') {
                     if (isset($last[$k]) && $last[$k] !== null && $last[$k] !== '') {
                         $profileData[$k] = $last[$k];
                     }
                 }
             }
-            // Use cached timestamp as lastconnected_ts fallback if missing
+            // Use cached timestamp as lastconnected_ts fallback if missing (legacy support)
             if ((!isset($profileData["lastconnected_ts"]) || $profileData["lastconnected_ts"] === null) && isset($last['ts']) && is_numeric($last['ts'])) {
                 $profileData["lastconnected_ts"] = (int) $last['ts'];
             }

--- a/src/profile.php
+++ b/src/profile.php
@@ -118,6 +118,17 @@ if ($onlineClient) {
     // Enhance with current channel and online since
     $profileData["cid"] = isset($onlineClient["cid"]) ? (int) $onlineClient["cid"] : null;
     $profileData["clid"] = isset($onlineClient["clid"]) ? (int) $onlineClient["clid"] : null;
+    
+    // Get live timestamps from online client (same as viewer hover data)
+    if (isset($onlineClient["client_created"]) && is_numeric($onlineClient["client_created"])) {
+        $profileData["created_ts"] = (int) $onlineClient["client_created"];
+    }
+    if (isset($onlineClient["client_lastconnected"]) && is_numeric($onlineClient["client_lastconnected"])) {
+        $profileData["lastconnected_ts"] = (int) $onlineClient["client_lastconnected"];
+    }
+    if (isset($onlineClient["client_totalconnections"]) && is_numeric($onlineClient["client_totalconnections"])) {
+        $profileData["totalconnections"] = (int) $onlineClient["client_totalconnections"];
+    }
 
     // Try to get more live info to compute "online since" timestamp
     try {
@@ -463,15 +474,16 @@ if (!$isOnline) {
 }
 
 // Compute human-readable first connected and last online date strings for Overview
+// Use the same format as viewer hover: DD/MM/YYYY HH:MM:SS
 if (isset($profileData["created_ts"]) && is_numeric($profileData["created_ts"])) {
-    $renderData["profile"]["first_connected_human"] = date('jS F, Y', (int) $profileData["created_ts"]);
+    $renderData["profile"]["first_connected_human"] = date('d/m/Y H:i:s', (int) $profileData["created_ts"]);
 }
 
 // Last online: show "Now" when online, or date/time when offline
 if ($isOnline) {
     $renderData["profile"]["last_online_human"] = "Now";
 } else if (isset($profileData["lastconnected_ts"]) && is_numeric($profileData["lastconnected_ts"])) {
-    $renderData["profile"]["last_online_human"] = date('jS F, Y, g:ia', (int) $profileData["lastconnected_ts"]);
+    $renderData["profile"]["last_online_human"] = date('d/m/Y H:i:s', (int) $profileData["lastconnected_ts"]);
 }
 
 TemplateUtils::i()->renderTemplate("profile", $renderData);

--- a/src/profile.php
+++ b/src/profile.php
@@ -342,7 +342,7 @@ if (!$isOnline) {
         $lastSeenCache = new PhpFileCache(__CACHE_DIR, "profile_last_seen");
         $last = $lastSeenCache->retrieve("u_" . (int) $cldbid);
         if (is_array($last)) {
-            foreach (["country", "version", "platform", "bw_up_h", "bw_down_h", "nickname"] as $k) {
+            foreach (["country", "version", "platform", "bw_up_h", "bw_down_h", "nickname", "totalconnections"] as $k) {
                 if (!isset($profileData[$k]) || $profileData[$k] === null || $profileData[$k] === '') {
                     if (isset($last[$k]) && $last[$k] !== null && $last[$k] !== '') {
                         $profileData[$k] = $last[$k];
@@ -466,7 +466,11 @@ if (!$isOnline) {
 if (isset($profileData["created_ts"]) && is_numeric($profileData["created_ts"])) {
     $renderData["profile"]["first_connected_human"] = date('jS F, Y', (int) $profileData["created_ts"]);
 }
-if (isset($profileData["lastconnected_ts"]) && is_numeric($profileData["lastconnected_ts"])) {
+
+// Last online: show "Now" when online, or date/time when offline
+if ($isOnline) {
+    $renderData["profile"]["last_online_human"] = "Now";
+} else if (isset($profileData["lastconnected_ts"]) && is_numeric($profileData["lastconnected_ts"])) {
     $renderData["profile"]["last_online_human"] = date('jS F, Y, g:ia', (int) $profileData["lastconnected_ts"]);
 }
 


### PR DESCRIPTION
Ensure 'Total connections' and 'First connected' are always displayed on profile pages, and 'Last online' shows 'Now' for online users.

The "Total connections" value now falls back to cached data when a user is offline, and the display logic for "Last online" has been updated to show "Now" with an online indicator when the user is active, improving the accuracy and completeness of profile information.

---
<a href="https://cursor.com/background-agent?bcId=bc-84058e91-bd9e-40a1-a35f-1accf72fcbbe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-84058e91-bd9e-40a1-a35f-1accf72fcbbe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

