### PR TITLE
Members page group sorting

### DIFF
--- a/src/members.php
+++ b/src/members.php
@@ -219,36 +219,49 @@ try {
 if (!empty($members) && $serverGroups) {
     $allIds = array_map(function ($m) { return (int) $m['cldbid']; }, $members);
     
-    // Get server groups from database profiles (already contains the data)
+    // Get server groups from live TeamSpeak server if connected, otherwise fall back to database profiles
+    $liveServerGroupsById = [];
+    if ($tsConnected) {
+        try {
+            $node = TeamSpeakUtils::i()->getTSNodeServer();
+            // Fetch live server groups for each member from TeamSpeak
+            foreach ($allIds as $cldbid) {
+                try {
+                    $sgList = $node->serverGroupsByClientId($cldbid);
+                    if ($sgList) {
+                        $groupIds = [];
+                        foreach ($sgList as $sg) {
+                            $gid = isset($sg['sgid']) ? (int) $sg['sgid'] : (isset($sg['servergroup_id']) ? (int) $sg['servergroup_id'] : null);
+                            if ($gid) {
+                                $groupIds[] = $gid;
+                            }
+                        }
+                        $liveServerGroupsById[$cldbid] = $groupIds;
+                    }
+                } catch (\Exception $e) { /* ignore individual lookup failures */ }
+            }
+        } catch (\Exception $e) { /* ignore TeamSpeak errors, will fall back to database */ }
+    }
+    
+    // Fallback: Get server groups from database profiles if TeamSpeak is not connected
     $profileSgById = [];
-    try {
-        $rows = $db->select('profiles', ['cldbid', 'servergroups'], ['cldbid' => $allIds]);
-        foreach ($rows as $r) { $profileSgById[(int)$r['cldbid']] = (string) $r['servergroups']; }
-    } catch (\Exception $e) { /* ignore */ }
-
-    // Cache for individual server group lookups (cache for 5 minutes)
-    $sgCache = new PhpFileCache(__CACHE_DIR, "member_servergroups");
+    if (empty($liveServerGroupsById)) {
+        try {
+            $rows = $db->select('profiles', ['cldbid', 'servergroups'], ['cldbid' => $allIds]);
+            foreach ($rows as $r) { $profileSgById[(int)$r['cldbid']] = (string) $r['servergroups']; }
+        } catch (\Exception $e) { /* ignore */ }
+    }
 
     foreach ($members as &$m) {
         $dbid = (int) $m['cldbid'];
         $sgids = [];
         
-        // Try to get from cache first
-        try {
-            $cached = $sgCache->retrieve("sg_" . $dbid);
-            if (is_array($cached)) {
-                $sgids = $cached;
-            }
-        } catch (\Exception $e) { /* cache miss, will fetch below */ }
-        
-        // If not in cache, get from database profile
-        if (empty($sgids) && isset($profileSgById[$dbid]) && $profileSgById[$dbid] !== '') {
+        // Prefer live TeamSpeak data over cached/database data
+        if (!empty($liveServerGroupsById[$dbid])) {
+            $sgids = $liveServerGroupsById[$dbid];
+        } elseif (isset($profileSgById[$dbid]) && $profileSgById[$dbid] !== '') {
+            // Fallback to database profile if live data not available
             $sgids = array_values(array_filter(array_map(function ($x) { return (int) trim($x); }, explode(',', $profileSgById[$dbid])), function ($v) { return $v > 0; }));
-            
-            // Store in cache for 5 minutes
-            try {
-                $sgCache->store("sg_" . $dbid, $sgids, 300);
-            } catch (\Exception $e) { /* ignore */ }
         }
         
         // Store all server groups for display

--- a/src/members.php
+++ b/src/members.php
@@ -192,9 +192,9 @@ if (!is_array($members)) {
         } catch (\Exception $e) { /* ignore */ }
     }
     
-    // Store in cache for 5 minutes (300 seconds)
+    // Store in cache for 1 minute (60 seconds) to ensure fresher data
     try {
-        $membersCache->store($cacheKey, $members, 300);
+        $membersCache->store($cacheKey, $members, 60);
     } catch (\Exception $e) { /* ignore cache errors */ }
 }
 
@@ -219,9 +219,17 @@ try {
 if (!empty($members) && $serverGroups) {
     $allIds = array_map(function ($m) { return (int) $m['cldbid']; }, $members);
     
+    // Check TeamSpeak connection status for live group fetching
+    $tsConnectedNow = false;
+    try {
+        $tsConnectedNow = TeamSpeakUtils::i()->checkTSConnection();
+    } catch (\Exception $e) {
+        $tsConnectedNow = false;
+    }
+    
     // Get server groups from live TeamSpeak server if connected, otherwise fall back to database profiles
     $liveServerGroupsById = [];
-    if ($tsConnected) {
+    if ($tsConnectedNow) {
         try {
             $node = TeamSpeakUtils::i()->getTSNodeServer();
             // Fetch live server groups for each member from TeamSpeak
@@ -252,6 +260,8 @@ if (!empty($members) && $serverGroups) {
         } catch (\Exception $e) { /* ignore */ }
     }
 
+    // Filter members: when using live data, remove users who no longer have any configured member groups
+    $filteredMembers = [];
     foreach ($members as &$m) {
         $dbid = (int) $m['cldbid'];
         $sgids = [];
@@ -259,6 +269,13 @@ if (!empty($members) && $serverGroups) {
         // Prefer live TeamSpeak data over cached/database data
         if (!empty($liveServerGroupsById[$dbid])) {
             $sgids = $liveServerGroupsById[$dbid];
+            
+            // Check if user still has any of the configured member groups
+            $hasConfiguredGroup = !empty(array_intersect($sgids, $memberGroups));
+            if (!$hasConfiguredGroup) {
+                // User no longer in any configured member groups, skip them
+                continue;
+            }
         } elseif (isset($profileSgById[$dbid]) && $profileSgById[$dbid] !== '') {
             // Fallback to database profile if live data not available
             $sgids = array_values(array_filter(array_map(function ($x) { return (int) trim($x); }, explode(',', $profileSgById[$dbid])), function ($v) { return $v > 0; }));
@@ -280,8 +297,14 @@ if (!empty($members) && $serverGroups) {
                 }
             }
         }
+        
+        // Add to filtered list
+        $filteredMembers[] = $m;
     }
     unset($m);
+    
+    // Use filtered members list (removes users no longer in configured groups when using live data)
+    $members = $filteredMembers;
 }
 
 TemplateUtils::i()->renderTemplate("members", [


### PR DESCRIPTION
Fetch live TeamSpeak server groups for members to ensure accurate group display.

The previous implementation relied on cached database profiles for displaying all groups for each user, leading to stale information where users removed from groups would still appear in them for up to 5 minutes. This PR ensures the displayed groups always reflect the current TeamSpeak server state.

---
<a href="https://cursor.com/background-agent?bcId=bc-c2a236d9-bc18-4801-bef3-7b455766a744"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c2a236d9-bc18-4801-bef3-7b455766a744"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

